### PR TITLE
Introduce Protocol Annotations

### DIFF
--- a/src/dkg/centralized_party/commitment_round.rs
+++ b/src/dkg/centralized_party/commitment_round.rs
@@ -109,7 +109,7 @@ impl<
             knowledge_of_discrete_log::PublicParameters::new::<GroupElement::Scalar, GroupElement>(
                 self.scalar_group_public_parameters.clone(),
                 self.group_public_parameters.clone(),
-                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
+                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters), // = G (Protocol 4)
             );
 
         // === Generate zero-knowledge proof for x_A ===

--- a/src/dkg/centralized_party/commitment_round.rs
+++ b/src/dkg/centralized_party/commitment_round.rs
@@ -80,7 +80,7 @@ impl<
 {
     /// This function implements step 1 of Protocol 4 (DKG):
     /// Samples x_A, computes X_A & zk-proof and commits to these values.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     pub fn sample_commit_and_prove_secret_key_share(
         self,
         rng: &mut impl CryptoRngCore,

--- a/src/dkg/centralized_party/commitment_round.rs
+++ b/src/dkg/centralized_party/commitment_round.rs
@@ -78,7 +78,8 @@ impl<
         ProtocolContext,
     >
 {
-    /// This function implements step 1 of Protocol 4 (DKG)
+    /// This function implements step 1 of Protocol 4 (DKG):
+    /// Samples x_A, computes X_A & zk-proof and commits to these values.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     pub fn sample_commit_and_prove_secret_key_share(
         self,

--- a/src/dkg/centralized_party/commitment_round.rs
+++ b/src/dkg/centralized_party/commitment_round.rs
@@ -78,9 +78,8 @@ impl<
         ProtocolContext,
     >
 {
-    /// This function implements Protocol 4, step 1 of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 1 of Protocol 4 (DKG)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     pub fn sample_commit_and_prove_secret_key_share(
         self,
         rng: &mut impl CryptoRngCore,

--- a/src/dkg/centralized_party/commitment_round.rs
+++ b/src/dkg/centralized_party/commitment_round.rs
@@ -103,18 +103,15 @@ impl<
         let secret_key_share =
             GroupElement::Scalar::sample(&self.scalar_group_public_parameters, rng)?;
 
-        // === Create L_DL language parameters ===
-        // Used in Protocol 4, step 2b
+        // === Construct proof for x_A ===
+        // Used in emulating the idealized F^{L_DL}_{com-zk} component
+        // Protocol 4, step 1b
         let language_public_parameters =
             knowledge_of_discrete_log::PublicParameters::new::<GroupElement::Scalar, GroupElement>(
                 self.scalar_group_public_parameters.clone(),
                 self.group_public_parameters.clone(),
                 GroupElement::generator_value_from_public_parameters(&self.group_public_parameters), // = G (Protocol 4)
             );
-
-        // === Generate zero-knowledge proof for x_A ===
-        // Used in emulating the idealized F^{L_DL}_{com-zk} component
-        // Protocol 4, step 1b
         let (knowledge_of_discrete_log_proof, public_key_share) = knowledge_of_discrete_log::Proof::<
             GroupElement::Scalar,
             GroupElement,

--- a/src/dkg/centralized_party/decommitment_round.rs
+++ b/src/dkg/centralized_party/decommitment_round.rs
@@ -204,9 +204,7 @@ where
                 self.scalar_group_public_parameters.clone(),
                 self.group_public_parameters.clone(),
                 self.encryption_scheme_public_parameters,
-
-                // = G (Protocol 4, step 2b)
-                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
+                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters), // = G (Protocol 4, step 2b)
             );
         let encryption_of_discrete_log_enhanced_language_public_parameters =
             enhanced_maurer::PublicParameters::new::<

--- a/src/dkg/centralized_party/decommitment_round.rs
+++ b/src/dkg/centralized_party/decommitment_round.rs
@@ -118,6 +118,9 @@ where
             UnboundedEncDLWitness,
         >,
 {
+    /// This function implements Protocol 4, step 3 of the
+    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
+    /// src: https://eprint.iacr.org/2024/253
     pub fn decommit_proof_public_key_share(
         self,
         decentralized_party_secret_key_share_encryption_and_proof: decentralized_party::SecretKeyShareEncryptionAndProof<
@@ -199,11 +202,10 @@ where
                 self.scalar_group_public_parameters.clone(),
                 self.group_public_parameters.clone(),
                 self.encryption_scheme_public_parameters,
-                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
-            );
 
-        // === Enhance Enc_DL parameters ===
-        // Include range proof capabilities
+                // = G (Protocol 4, step 2b)
+                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters), 
+            );
         let encryption_of_discrete_log_enhanced_language_public_parameters =
             enhanced_maurer::PublicParameters::new::<
                 RangeProof,
@@ -236,7 +238,7 @@ where
         // Protocol 4, step 5a
         let public_key = self.public_key_share.clone() + &decentralized_party_public_key_share;
 
-        // === Generate
+        // === Generate public key share proof ===
         // Protocol 4, step 3c
         // Used to emulate idealized F^{L_DL}_{com-zk}
         let public_key_share = self.public_key_share.value();

--- a/src/dkg/centralized_party/decommitment_round.rs
+++ b/src/dkg/centralized_party/decommitment_round.rs
@@ -118,9 +118,8 @@ where
             UnboundedEncDLWitness,
         >,
 {
-    /// This function implements Protocol 4, steps 3 and 5 of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements steps 3 and 5 of Protocol 4 (DKG)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     pub fn decommit_proof_public_key_share(
         self,
         decentralized_party_secret_key_share_encryption_and_proof: decentralized_party::SecretKeyShareEncryptionAndProof<

--- a/src/dkg/centralized_party/decommitment_round.rs
+++ b/src/dkg/centralized_party/decommitment_round.rs
@@ -118,7 +118,7 @@ where
             UnboundedEncDLWitness,
         >,
 {
-    /// This function implements Protocol 4, step 3 of the
+    /// This function implements Protocol 4, steps 3 and 5 of the
     /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
     /// src: https://eprint.iacr.org/2024/253
     pub fn decommit_proof_public_key_share(
@@ -155,7 +155,7 @@ where
             group::Value<EncryptionKey::CiphertextSpaceGroupElement>,
         >,
     )> {
-        // === enc(x_B) ===
+        // = enc(x_B)
         let encrypted_decentralized_party_secret_key_share =
             EncryptionKey::CiphertextSpaceGroupElement::new(
                 decentralized_party_secret_key_share_encryption_and_proof
@@ -164,7 +164,7 @@ where
                     .ciphertext_space_public_parameters(),
             )?;
 
-        // === X_B ===
+        // = X_B
         let decentralized_party_public_key_share = GroupElement::new(
             decentralized_party_secret_key_share_encryption_and_proof.public_key_share,
             &self.group_public_parameters,
@@ -191,7 +191,9 @@ where
         )
             .into();
 
-        // === Generate Enc_DL parameters ===
+        // Construct L_EncDL parameters
+        // Used in emulating the idealized F^{L_EncDL}_{agg-zk} component
+        // Protocol 4, step 3a
         let encryption_of_discrete_log_language_public_parameters =
             encryption_of_discrete_log::PublicParameters::<
                 PLAINTEXT_SPACE_SCALAR_LIMBS,
@@ -238,9 +240,9 @@ where
         // Protocol 4, step 5a
         let public_key = self.public_key_share.clone() + &decentralized_party_public_key_share;
 
-        // === Generate public key share proof ===
-        // Protocol 4, step 3c
+        // === Construct X_A proof object ===
         // Used to emulate idealized F^{L_DL}_{com-zk}
+        // Protocol 4, step 3c
         let public_key_share = self.public_key_share.value();
         let public_key_share_decommitment_proof = PublicKeyShareDecommitmentAndProof::<
             GroupElement::Value,

--- a/src/dkg/centralized_party/decommitment_round.rs
+++ b/src/dkg/centralized_party/decommitment_round.rs
@@ -118,7 +118,8 @@ where
             UnboundedEncDLWitness,
         >,
 {
-    /// This function implements steps 3 and 5 of Protocol 4 (DKG)
+    /// This function implements steps 3 and 5 of Protocol 4 (DKG):
+    /// Verifies zk-proof for X_B and computes X := X_A + X_B.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     pub fn decommit_proof_public_key_share(
         self,

--- a/src/dkg/centralized_party/decommitment_round.rs
+++ b/src/dkg/centralized_party/decommitment_round.rs
@@ -206,7 +206,7 @@ where
                 self.encryption_scheme_public_parameters,
 
                 // = G (Protocol 4, step 2b)
-                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters), 
+                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
             );
         let encryption_of_discrete_log_enhanced_language_public_parameters =
             enhanced_maurer::PublicParameters::new::<

--- a/src/dkg/centralized_party/decommitment_round.rs
+++ b/src/dkg/centralized_party/decommitment_round.rs
@@ -120,7 +120,7 @@ where
 {
     /// This function implements steps 3 and 5 of Protocol 4 (DKG):
     /// Verifies zk-proof for X_B and computes X := X_A + X_B.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     pub fn decommit_proof_public_key_share(
         self,
         decentralized_party_secret_key_share_encryption_and_proof: decentralized_party::SecretKeyShareEncryptionAndProof<

--- a/src/dkg/decentralized_party.rs
+++ b/src/dkg/decentralized_party.rs
@@ -115,11 +115,13 @@ where
             ProtocolContext,
         >,
     ) -> Self {
+        // = x_i
         let encrypted_secret_key_share = encryption_of_secret_share
             .language_statement()
             .encrypted_discrete_log()
             .value();
 
+        // = X_i
         let public_key_share = encryption_of_secret_share
             .language_statement()
             .base_by_discrete_log()

--- a/src/dkg/decentralized_party/decommitment_proof_verification_round.rs
+++ b/src/dkg/decentralized_party/decommitment_proof_verification_round.rs
@@ -164,11 +164,11 @@ where
         // Used in emulating idealized F^{L_DL}_{com-zk}
         // Protocol 4, step 4a
         let language_public_parameters =
-        knowledge_of_discrete_log::PublicParameters::new::<GroupElement::Scalar, GroupElement>(
-            self.scalar_group_public_parameters.clone(),
-            self.group_public_parameters.clone(),
-            GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
-        );        
+            knowledge_of_discrete_log::PublicParameters::new::<GroupElement::Scalar, GroupElement>(
+                self.scalar_group_public_parameters.clone(),
+                self.group_public_parameters.clone(),
+                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
+            );
         decommitment_and_proof.proof.verify(
             &self.protocol_context,
             &language_public_parameters,

--- a/src/dkg/decentralized_party/decommitment_proof_verification_round.rs
+++ b/src/dkg/decentralized_party/decommitment_proof_verification_round.rs
@@ -104,9 +104,8 @@ where
             UnboundedEncDLWitness,
         >,
 {
-    /// This function implements Protocol 4, steps 4 and 5 of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements steps 4 and 5 of Protocol 4 (DKG)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     pub fn verify_decommitment_and_proof_of_centralized_party_public_key_share(
         self,
         decommitment_and_proof: centralized_party::PublicKeyShareDecommitmentAndProof<

--- a/src/dkg/decentralized_party/decommitment_proof_verification_round.rs
+++ b/src/dkg/decentralized_party/decommitment_proof_verification_round.rs
@@ -106,7 +106,7 @@ where
 {
     /// This function implements steps 4 and 5 of Protocol 4 (DKG):
     /// Verifies commitment and zk-proof for X_A, and computes X := X_A + X_B.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     pub fn verify_decommitment_and_proof_of_centralized_party_public_key_share(
         self,
         decommitment_and_proof: centralized_party::PublicKeyShareDecommitmentAndProof<

--- a/src/dkg/decentralized_party/decommitment_proof_verification_round.rs
+++ b/src/dkg/decentralized_party/decommitment_proof_verification_round.rs
@@ -104,7 +104,8 @@ where
             UnboundedEncDLWitness,
         >,
 {
-    /// This function implements steps 4 and 5 of Protocol 4 (DKG)
+    /// This function implements steps 4 and 5 of Protocol 4 (DKG):
+    /// Verifies commitment and zk-proof for X_A, and computes X := X_A + X_B.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     pub fn verify_decommitment_and_proof_of_centralized_party_public_key_share(
         self,

--- a/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
+++ b/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
@@ -101,7 +101,7 @@ where
 {
     /// This function implements step 2 of Protocol 4 (DKG):
     /// Samples x_i and prepares computation of ct_i & its zk-proof.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     pub fn sample_secret_key_share_and_initialize_proof_aggregation(
         self,
         commitment_to_centralized_party_secret_key_share: Commitment,

--- a/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
+++ b/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
@@ -240,7 +240,7 @@ where
         // By calling `commit_statements_and_statement_mask` on this party,
         // ct_i is created.
         //
-        // sources: 
+        // sources:
         // --------
         // maurer::aggregation::commitment_round::commit_statements_and_statement_mask.
         // ct_i = enhanced_maurer::Language::homomorphose(witnesses, &enc_dl_public_parameters).

--- a/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
+++ b/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
@@ -99,6 +99,9 @@ where
             UnboundedEncDLWitness,
         >,
 {
+    /// This function implements Protocol 4, step 2 of the
+    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
+    /// src: https://eprint.iacr.org/2024/253
     pub fn sample_secret_key_share_and_initialize_proof_aggregation(
         self,
         commitment_to_centralized_party_secret_key_share: Commitment,
@@ -152,7 +155,9 @@ where
             rng,
         )?;
 
-        // Construct EncDL language parameters, step 1.
+        // Construct L_EncDL parameters
+        // Used in emulating the idealized F^{L_EncDL}_{agg-zk} component
+        // Protocol 4, steps 2e and 2f.
         let language_public_parameters =
             encryption_of_discrete_log::PublicParameters::<
                 PLAINTEXT_SPACE_SCALAR_LIMBS,
@@ -165,9 +170,6 @@ where
                 self.encryption_scheme_public_parameters.clone(),
                 GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
             );
-        
-        // Enhance; add range proof support to language
-        // Used in Protocol 4, steps 2e and 2f.
         let language_public_parameters = EnhancedPublicParameters::<
             SOUND_PROOFS_REPETITIONS,
             RANGE_CLAIMS_PER_SCALAR,
@@ -196,7 +198,7 @@ where
         )?;
 
         // === Map (x_i, ρ_i) ====
-        // map it to the triple
+        // map (x_i, ρ_i) to the triple
         // * [commitment_message]    cm_i = x_i
         // * [commitment_randomness] cr_i = randomly sampled value
         // * [unbounded_witness]     uw_i = ρ_i

--- a/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
+++ b/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
@@ -232,15 +232,16 @@ where
             rng,
         )?;
 
-        // === Create commitment round party ===
+        // === Prepare ct_i computation ===
+        // Protocol 4, step 2d
         //
-        // This round party consists of
-        // * Range proof commitment party
-        //   - contains (cm_i, cr_i)
+        // By calling `commit_statements_and_statement_mask` on this party,
+        // ct_i is created.
         //
-        // * Maurer commmitment party.
-        //   - contains (cm_i, cr_i, ρ_i), and
-        //   - more randomly sampled (message, randomness, witness) triples
+        // sources: 
+        // --------
+        // maurer::aggregation::commitment_round::commit_statements_and_statement_mask.
+        // ct_i = enhanced_maurer::Language::homomorphose(witnesses, &enc_dl_public_parameters).
         let encryption_of_secret_share_commitment_round_party =
             enhanced_maurer::aggregation::commitment_round::Party::<
                 SOUND_PROOFS_REPETITIONS,

--- a/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
+++ b/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
@@ -99,7 +99,8 @@ where
             UnboundedEncDLWitness,
         >,
 {
-    /// This function implements step 2 of Protocol 4 (DKG)
+    /// This function implements step 2 of Protocol 4 (DKG):
+    /// Samples x_i and prepares computation of ct_i & its zk-proof.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     pub fn sample_secret_key_share_and_initialize_proof_aggregation(
         self,

--- a/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
+++ b/src/dkg/decentralized_party/encryption_of_secret_key_share_round.rs
@@ -99,9 +99,8 @@ where
             UnboundedEncDLWitness,
         >,
 {
-    /// This function implements Protocol 4, step 2 of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 2 of Protocol 4 (DKG)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     pub fn sample_secret_key_share_and_initialize_proof_aggregation(
         self,
         commitment_to_centralized_party_secret_key_share: Commitment,

--- a/src/presign/centralized_party.rs
+++ b/src/presign/centralized_party.rs
@@ -12,5 +12,5 @@ pub struct Presign<GroupElementValue, ScalarValue, CiphertextValue> {
     pub(crate) decentralized_party_nonce_public_share: GroupElementValue, // $R_B$
     pub(crate) encrypted_mask: CiphertextValue, // $\ct_1$
     pub(crate) encrypted_masked_key_share: CiphertextValue, // $\ct_2$
-    pub(crate) commitment_randomness: ScalarValue, // $\rho$
+    pub(crate) commitment_randomness: ScalarValue, // $ρ_1$
 }

--- a/src/presign/centralized_party.rs
+++ b/src/presign/centralized_party.rs
@@ -9,7 +9,7 @@ pub mod proof_verification_round;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Presign<GroupElementValue, ScalarValue, CiphertextValue> {
     pub(crate) nonce_share: ScalarValue, // $k_A$
-    pub(crate) decentralized_party_nonce_public_share: GroupElementValue, // $K_A$
+    pub(crate) decentralized_party_nonce_public_share: GroupElementValue, // $R_B$
     pub(crate) encrypted_mask: CiphertextValue, // $\ct_1$
     pub(crate) encrypted_masked_key_share: CiphertextValue, // $\ct_2$
     pub(crate) commitment_randomness: ScalarValue, // $\rho$

--- a/src/presign/centralized_party/commitment_round.rs
+++ b/src/presign/centralized_party/commitment_round.rs
@@ -76,6 +76,9 @@ impl<
         ProtocolContext,
     >
 {
+    /// This function implements Protocol 5, step 1 of the
+    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
+    /// src: https://eprint.iacr.org/2024/253
     pub fn sample_commit_and_prove_signature_nonce_share(
         self,
         batch_size: usize,
@@ -107,36 +110,46 @@ impl<
             ProtocolContext,
         >,
     )> {
+        // Note: this function works in batches; the annotations are written as
+        // if the batch has size = 1.
+
+        // === Sample k_A ===
+        // Protocol 5, step 1a
         let signature_nonce_shares = GroupElement::Scalar::sample_batch(
             &self.scalar_group_public_parameters,
             batch_size,
             rng,
         )?;
 
+        // === Sample ρ_1 ===
+        // Protocol 5, step 1a
         let commitment_randomnesses = GroupElement::Scalar::sample_batch(
             &self.scalar_group_public_parameters,
             batch_size,
             rng,
         )?;
 
+        // Create (k_A, ρ_1) tuple
         let signature_nonce_shares_and_commitment_randomnesses: Vec<_> = signature_nonce_shares
             .into_iter()
             .zip(commitment_randomnesses)
             .map(|(nonce_share, commitment_randomness)| [nonce_share, commitment_randomness].into())
             .collect();
 
+        // Generate L_DCom parameters
         let commitment_scheme_public_parameters =
             pedersen::PublicParameters::derive::<SCALAR_LIMBS, GroupElement>(
                 self.scalar_group_public_parameters.clone(),
                 self.group_public_parameters.clone(),
             )?;
-
         let language_public_parameters = knowledge_of_decommitment::PublicParameters::new::<
             SOUND_PROOFS_REPETITIONS,
             SCALAR_LIMBS,
             Pedersen<1, SCALAR_LIMBS, GroupElement::Scalar, GroupElement>,
         >(commitment_scheme_public_parameters.clone());
 
+        // === Create proof and commitment ===
+        // Protocol 5, steps 1b and 1a, respectively
         let (proof, commitments) = maurer::Proof::<
             SOUND_PROOFS_REPETITIONS,
             knowledge_of_decommitment::Language<

--- a/src/presign/centralized_party/commitment_round.rs
+++ b/src/presign/centralized_party/commitment_round.rs
@@ -79,6 +79,9 @@ impl<
     /// This function implements Protocol 5, step 1 of the
     /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
     /// src: https://eprint.iacr.org/2024/253
+    /// 
+    /// Note: this function operates on batches; the annotations are written as
+    /// if the batch size equals 1.
     pub fn sample_commit_and_prove_signature_nonce_share(
         self,
         batch_size: usize,
@@ -110,9 +113,6 @@ impl<
             ProtocolContext,
         >,
     )> {
-        // Note: this function works in batches; the annotations are written as
-        // if the batch has size = 1.
-
         // === Sample k_A ===
         // Protocol 5, step 1a
         let signature_nonce_shares = GroupElement::Scalar::sample_batch(
@@ -136,7 +136,7 @@ impl<
             .map(|(nonce_share, commitment_randomness)| [nonce_share, commitment_randomness].into())
             .collect();
 
-        // Generate L_DCom parameters
+        // Construct L_DCom parameters
         let commitment_scheme_public_parameters =
             pedersen::PublicParameters::derive::<SCALAR_LIMBS, GroupElement>(
                 self.scalar_group_public_parameters.clone(),
@@ -148,7 +148,7 @@ impl<
             Pedersen<1, SCALAR_LIMBS, GroupElement::Scalar, GroupElement>,
         >(commitment_scheme_public_parameters.clone());
 
-        // === Create proof and commitment ===
+        // === Create proof and commitment to k_A ===
         // Protocol 5, steps 1b and 1a, respectively
         let (proof, commitments) = maurer::Proof::<
             SOUND_PROOFS_REPETITIONS,

--- a/src/presign/centralized_party/commitment_round.rs
+++ b/src/presign/centralized_party/commitment_round.rs
@@ -76,7 +76,8 @@ impl<
         ProtocolContext,
     >
 {
-    /// This function implements step 1 of Protocol 5 (Presign)
+    /// This function implements step 1 of Protocol 5 (Presign):
+    /// Samples k_A, computes K_A & its zk-proof and commits to these values.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Note: this function operates on batches; the annotations are written as

--- a/src/presign/centralized_party/commitment_round.rs
+++ b/src/presign/centralized_party/commitment_round.rs
@@ -76,9 +76,8 @@ impl<
         ProtocolContext,
     >
 {
-    /// This function implements Protocol 5, step 1 of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 1 of Protocol 5 (Presign)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.

--- a/src/presign/centralized_party/commitment_round.rs
+++ b/src/presign/centralized_party/commitment_round.rs
@@ -78,7 +78,7 @@ impl<
 {
     /// This function implements step 1 of Protocol 5 (Presign):
     /// Samples k_A, computes K_A & its zk-proof and commits to these values.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.

--- a/src/presign/centralized_party/commitment_round.rs
+++ b/src/presign/centralized_party/commitment_round.rs
@@ -79,7 +79,7 @@ impl<
     /// This function implements Protocol 5, step 1 of the
     /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
     /// src: https://eprint.iacr.org/2024/253
-    /// 
+    ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.
     pub fn sample_commit_and_prove_signature_nonce_share(

--- a/src/presign/centralized_party/proof_verification_round.rs
+++ b/src/presign/centralized_party/proof_verification_round.rs
@@ -135,6 +135,9 @@ where
     /// This function implements Protocol 5, step 3 of the
     /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
     /// src: https://eprint.iacr.org/2024/253
+    /// 
+    /// Note: this function operates on batches; the annotations are written as
+    /// if the batch size equals 1.
     pub fn verify_presign_output(
         self,
         output: decentralized_party::Output<
@@ -184,9 +187,6 @@ where
             >,
         >,
     > {
-        // Note: this function works in batches; the annotations are written as
-        // if the batch has size = 1.
-
         let batch_size = self
             .signature_nonce_shares_and_commitment_randomnesses
             .len();
@@ -247,7 +247,7 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
-        // Gather EncDH language public parameters
+        // Construct L_EncDH language public parameters
         let encrypted_secret_key_share_upper_bound = composed_witness_upper_bound::<
             RANGE_CLAIMS_PER_SCALAR,
             PLAINTEXT_SPACE_SCALAR_LIMBS,
@@ -292,7 +292,7 @@ where
             language_public_parameters,
         )?;
 
-        // === Verify proof ===
+        // === Verify ct_1, ct_2 proof ===
         // Protocol 5, step 3b
         let statements = encrypted_masks
             .into_iter()
@@ -361,7 +361,7 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
-        // Gather EncDL public parameters
+        // Construct L_EncDL public parameters
         let language_public_parameters =
             encryption_of_discrete_log::PublicParameters::<
                 PLAINTEXT_SPACE_SCALAR_LIMBS,
@@ -401,7 +401,7 @@ where
             language_public_parameters,
         )?;
 
-        // === Verify proof ===
+        // === Verify ct_3 proof ===
         // Protocol 5, step 3a
         let statements = encrypted_nonces
             .into_iter()

--- a/src/presign/centralized_party/proof_verification_round.rs
+++ b/src/presign/centralized_party/proof_verification_round.rs
@@ -135,7 +135,7 @@ where
     /// This function implements Protocol 5, step 3 of the
     /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
     /// src: https://eprint.iacr.org/2024/253
-    /// 
+    ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.
     pub fn verify_presign_output(

--- a/src/presign/centralized_party/proof_verification_round.rs
+++ b/src/presign/centralized_party/proof_verification_round.rs
@@ -134,7 +134,7 @@ where
 {
     /// This function implements step 3 of Protocol 5 (Presign):
     /// Verifies zk-proofs for ct_1, ct_2 and ct_3.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.

--- a/src/presign/centralized_party/proof_verification_round.rs
+++ b/src/presign/centralized_party/proof_verification_round.rs
@@ -132,9 +132,8 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
-    /// This function implements Protocol 5, step 3 of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 3 of Protocol 5 (Presign)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.

--- a/src/presign/centralized_party/proof_verification_round.rs
+++ b/src/presign/centralized_party/proof_verification_round.rs
@@ -132,7 +132,8 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
-    /// This function implements step 3 of Protocol 5 (Presign)
+    /// This function implements step 3 of Protocol 5 (Presign):
+    /// Verifies zk-proofs for ct_1, ct_2 and ct_3.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Note: this function operates on batches; the annotations are written as

--- a/src/presign/centralized_party/proof_verification_round.rs
+++ b/src/presign/centralized_party/proof_verification_round.rs
@@ -132,6 +132,9 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
+    /// This function implements Protocol 5, step 3 of the
+    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
+    /// src: https://eprint.iacr.org/2024/253
     pub fn verify_presign_output(
         self,
         output: decentralized_party::Output<
@@ -181,6 +184,9 @@ where
             >,
         >,
     > {
+        // Note: this function works in batches; the annotations are written as
+        // if the batch has size = 1.
+
         let batch_size = self
             .signature_nonce_shares_and_commitment_randomnesses
             .len();
@@ -192,6 +198,8 @@ where
             return Err(Error::InvalidParameters);
         }
 
+        // = ct_1
+        // = AHE.Enc(γ)
         let encrypted_masks = output
             .encrypted_masks
             .clone()
@@ -205,6 +213,9 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
+        // = ct_2
+        // = AHE.Enc(γ) * ct_key
+        // = AHE.Enc(γ * x_B)
         let encrypted_masked_key_shares = output
             .encrypted_masked_key_shares
             .clone()
@@ -218,6 +229,7 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
+        // commitments to the range proof of γ
         let key_share_masking_range_proof_commitments = output
             .key_share_masking_range_proof_commitments
             .into_iter()
@@ -235,31 +247,13 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
-        let statements = encrypted_masks
-            .into_iter()
-            .zip(encrypted_masked_key_shares)
-            .zip(key_share_masking_range_proof_commitments)
-            .map(
-                |(
-                    (encrypted_mask, encrypted_masked_key_share),
-                    key_share_masking_range_proof_commitment,
-                )| {
-                    (
-                        key_share_masking_range_proof_commitment,
-                        [encrypted_mask, encrypted_masked_key_share].into(),
-                    )
-                        .into()
-                },
-            )
-            .collect();
-
+        // Gather EncDH language public parameters
         let encrypted_secret_key_share_upper_bound = composed_witness_upper_bound::<
             RANGE_CLAIMS_PER_SCALAR,
             PLAINTEXT_SPACE_SCALAR_LIMBS,
             COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
             RangeProof,
         >()?;
-
         let language_public_parameters = encryption_of_tuple::PublicParameters::<
             PLAINTEXT_SPACE_SCALAR_LIMBS,
             SCALAR_LIMBS,
@@ -271,7 +265,6 @@ where
             self.encrypted_decentralized_party_secret_key_share.value(),
             encrypted_secret_key_share_upper_bound,
         );
-
         let language_public_parameters = EnhancedPublicParameters::<
             SOUND_PROOFS_REPETITIONS,
             RANGE_CLAIMS_PER_SCALAR,
@@ -299,6 +292,25 @@ where
             language_public_parameters,
         )?;
 
+        // === Verify proof ===
+        // Protocol 5, step 3b
+        let statements = encrypted_masks
+            .into_iter()
+            .zip(encrypted_masked_key_shares)
+            .zip(key_share_masking_range_proof_commitments)
+            .map(
+                |(
+                    (encrypted_mask, encrypted_masked_key_share),
+                    key_share_masking_range_proof_commitment,
+                )| {
+                    (
+                        key_share_masking_range_proof_commitment,
+                        [encrypted_mask, encrypted_masked_key_share].into(),
+                    )
+                        .into()
+                },
+            )
+            .collect();
         output.masks_and_encrypted_masked_key_share_proof.verify(
             &self.protocol_context,
             &language_public_parameters,
@@ -306,6 +318,8 @@ where
             rng,
         )?;
 
+        // = ct_3
+        // = AHE.Enc(k)
         let encrypted_nonces = output
             .encrypted_nonces
             .clone()
@@ -319,6 +333,7 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
+        // = R_B
         let decentralized_party_nonce_public_shares = output
             .nonce_public_shares
             .clone()
@@ -328,6 +343,7 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
+        // commitments to the range proof of k
         let nonce_sharing_range_proof_commitments = output
             .nonce_sharing_range_proof_commitments
             .into_iter()
@@ -345,21 +361,7 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
-        let statements = encrypted_nonces
-            .into_iter()
-            .zip(decentralized_party_nonce_public_shares)
-            .zip(nonce_sharing_range_proof_commitments)
-            .map(
-                |((encrypted_nonce, nonce_public_share), nonce_sharing_range_proof_commitment)| {
-                    (
-                        nonce_sharing_range_proof_commitment,
-                        (encrypted_nonce, nonce_public_share).into(),
-                    )
-                        .into()
-                },
-            )
-            .collect();
-
+        // Gather EncDL public parameters
         let language_public_parameters =
             encryption_of_discrete_log::PublicParameters::<
                 PLAINTEXT_SPACE_SCALAR_LIMBS,
@@ -372,7 +374,6 @@ where
                 self.encryption_scheme_public_parameters.clone(),
                 GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
             );
-
         let language_public_parameters = EnhancedPublicParameters::<
             SOUND_PROOFS_REPETITIONS,
             RANGE_CLAIMS_PER_SCALAR,
@@ -400,6 +401,22 @@ where
             language_public_parameters,
         )?;
 
+        // === Verify proof ===
+        // Protocol 5, step 3a
+        let statements = encrypted_nonces
+            .into_iter()
+            .zip(decentralized_party_nonce_public_shares)
+            .zip(nonce_sharing_range_proof_commitments)
+            .map(
+                |((encrypted_nonce, nonce_public_share), nonce_sharing_range_proof_commitment)| {
+                    (
+                        nonce_sharing_range_proof_commitment,
+                        (encrypted_nonce, nonce_public_share).into(),
+                    )
+                        .into()
+                },
+            )
+            .collect();
         output
             .encrypted_nonce_shares_and_public_shares_proof
             .verify(
@@ -429,11 +446,11 @@ where
                     ),
                 )| {
                     Presign {
-                        nonce_share: nonce_share.value(),
-                        decentralized_party_nonce_public_share,
-                        encrypted_mask,
-                        encrypted_masked_key_share,
-                        commitment_randomness: commitment_randomness.value(),
+                        nonce_share: nonce_share.value(),                     // = k_A
+                        decentralized_party_nonce_public_share,               // = R_B
+                        encrypted_mask,                                       // = ct_1
+                        encrypted_masked_key_share,                           // = ct_2
+                        commitment_randomness: commitment_randomness.value(), // = ρ_1
                     }
                 },
             )

--- a/src/presign/decentralized_party.rs
+++ b/src/presign/decentralized_party.rs
@@ -429,11 +429,11 @@ impl<
 
         Ok(Presign {
             centralized_party_nonce_share_commitment: centralized_party_nonce_share_commitment
-                .value(),                   // = K_A
-            nonce_public_share,             // = R_B            
-            encrypted_mask,                 // = ct_1 = AHE.Enc(γ)
-            encrypted_masked_key_share,     // = ct_2 = AHE.Enc(γ * x_B)
-            encrypted_masked_nonce_share,   // = ct_4 = AHE.Enc(k * γ * x_B)
+                .value(), // = K_A
+            nonce_public_share,           // = R_B
+            encrypted_mask,               // = ct_1 = AHE.Enc(γ)
+            encrypted_masked_key_share,   // = ct_2 = AHE.Enc(γ * x_B)
+            encrypted_masked_nonce_share, // = ct_4 = AHE.Enc(k * γ * x_B)
         })
     }
 

--- a/src/presign/decentralized_party.rs
+++ b/src/presign/decentralized_party.rs
@@ -353,14 +353,17 @@ impl<
             group::GroupElement<Value = GroupElementValue> + PrimeGroupElement<SCALAR_LIMBS>,
         EncryptionKey::CiphertextSpaceGroupElement: group::GroupElement<Value = CiphertextValue>,
     {
+        // = ct_1
         let encrypted_mask = mask_and_encrypted_masked_key_share
             .encrypted_multiplicand()
             .value();
 
+        // = ct_2
         let encrypted_masked_key_share = mask_and_encrypted_masked_key_share
             .encrypted_product()
             .value();
 
+        // = R_B
         let nonce_public_share = encrypted_nonce_share_and_public_share
             .base_by_discrete_log()
             .value();

--- a/src/presign/decentralized_party.rs
+++ b/src/presign/decentralized_party.rs
@@ -205,6 +205,8 @@ where
             return Err(Error::InvalidParameters);
         }
 
+        // = ct_1
+        // = AHE.Enc(γ)
         let encrypted_masks: Vec<_> = masks_and_encrypted_masked_key_share
             .iter()
             .map(|mask_and_encrypted_masked_key_share| {
@@ -215,6 +217,9 @@ where
             })
             .collect();
 
+        // = ct_2
+        // = AHE.Enc(γ) * ct_key
+        // = AHE.Enc(γ * x_B)
         let encrypted_masked_key_shares: Vec<_> = masks_and_encrypted_masked_key_share
             .iter()
             .map(|mask_and_encrypted_masked_key_share| {
@@ -225,6 +230,7 @@ where
             })
             .collect();
 
+        // commitments for range proof on γ
         let key_share_masking_range_proof_commitments: Vec<_> =
             masks_and_encrypted_masked_key_share
                 .iter()
@@ -235,6 +241,8 @@ where
                 })
                 .collect();
 
+        // = ct_3
+        // = AHE.Enc(k)
         let encrypted_nonces: Vec<_> = encrypted_nonce_shares_and_public_shares
             .iter()
             .map(|nonce_share_encryption_and_public_share| {
@@ -245,6 +253,7 @@ where
             })
             .collect();
 
+        // = R_B
         let nonce_public_shares: Vec<_> = encrypted_nonce_shares_and_public_shares
             .iter()
             .map(|nonce_share_encryption_and_public_share| {
@@ -255,6 +264,7 @@ where
             })
             .collect();
 
+        // commitments to the range proof of k
         let nonce_sharing_range_proof_commitments: Vec<_> =
             encrypted_nonce_shares_and_public_shares
                 .iter()
@@ -416,11 +426,11 @@ impl<
 
         Ok(Presign {
             centralized_party_nonce_share_commitment: centralized_party_nonce_share_commitment
-                .value(),
-            nonce_public_share,
-            encrypted_mask,
-            encrypted_masked_key_share,
-            encrypted_masked_nonce_share,
+                .value(),                   // = K_A
+            nonce_public_share,             // = R_B            
+            encrypted_mask,                 // = ct_1 = AHE.Enc(γ)
+            encrypted_masked_key_share,     // = ct_2 = AHE.Enc(γ * x_B)
+            encrypted_masked_nonce_share,   // = ct_4 = AHE.Enc(k * γ * x_B)
         })
     }
 

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -335,10 +335,6 @@ where
         )?;
 
         // Create (γ_i, η^i_1, η^i_2) tuples
-        // The elements are henceforth referred to as
-        // - multiplicand,
-        // - multiplicand randomness,
-        // - product randomness
         let witnesses = mask_shares_witnesses
             .clone()
             .into_iter()

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -215,7 +215,7 @@ where
 
         // Construct L_DCOM language parameters
         // Used in emulating F^{L_DCOM}_zk
-        let language_public_parameters = knowledge_of_decommitment::PublicParameters::new::<
+        let l_dcom_public_parameters = knowledge_of_decommitment::PublicParameters::new::<
             SOUND_PROOFS_REPETITIONS,
             SCALAR_LIMBS,
             Pedersen<1, SCALAR_LIMBS, GroupElement::Scalar, GroupElement>,
@@ -233,7 +233,7 @@ where
             .proof
             .verify(
                 &self.protocol_context,
-                &language_public_parameters,
+                &l_dcom_public_parameters,
                 centralized_party_nonce_shares_commitments.clone(),
             )?;
 
@@ -292,7 +292,8 @@ where
             RangeProof,
         >()?;
 
-        let language_public_parameters = encryption_of_tuple::PublicParameters::<
+        // Generate EncDH public parameters
+        let enc_dh_public_parameters = encryption_of_tuple::PublicParameters::<
             PLAINTEXT_SPACE_SCALAR_LIMBS,
             SCALAR_LIMBS,
             GroupElement,
@@ -303,8 +304,7 @@ where
             self.encrypted_secret_key_share.value(),
             encrypted_secret_key_share_upper_bound,
         );
-
-        let language_public_parameters = EnhancedPublicParameters::<
+        let enc_dh_public_parameters = EnhancedPublicParameters::<
             SOUND_PROOFS_REPETITIONS,
             RANGE_CLAIMS_PER_SCALAR,
             COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
@@ -328,7 +328,7 @@ where
         >(
             self.unbounded_encdh_witness_public_parameters.clone(),
             self.range_proof_public_parameters.clone(),
-            language_public_parameters,
+            enc_dh_public_parameters,
         )?;
 
         // Create (γ_i, η^i_1, η^i_2) tuples
@@ -381,7 +381,7 @@ where
                 GroupElement,
                 EncryptionKey,
             >,
-        >::generate_witnesses(witnesses, &language_public_parameters, rng)?;
+        >::generate_witnesses(witnesses, &enc_dh_public_parameters, rng)?;
 
         // === Create EncDH commitment round party ===
         //
@@ -409,7 +409,7 @@ where
             >::new_session(
                 self.party_id,
                 self.parties.clone(),
-                language_public_parameters,
+                enc_dh_public_parameters,
                 self.protocol_context.clone(),
                 witnesses,
                 rng,
@@ -455,7 +455,8 @@ where
                 rng,
             )?;
 
-        let language_public_parameters =
+        // Generate EncDL public parameters
+        let enc_dl_public_parameters =
             encryption_of_discrete_log::PublicParameters::<
                 PLAINTEXT_SPACE_SCALAR_LIMBS,
                 SCALAR_LIMBS,
@@ -467,8 +468,7 @@ where
                 self.encryption_scheme_public_parameters.clone(),
                 GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
             );
-
-        let language_public_parameters = EnhancedPublicParameters::<
+        let enc_dl_public_parameters = EnhancedPublicParameters::<
             SOUND_PROOFS_REPETITIONS,
             RANGE_CLAIMS_PER_SCALAR,
             COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
@@ -492,7 +492,7 @@ where
         >(
             self.unbounded_encdl_witness_public_parameters.clone(),
             self.range_proof_public_parameters.clone(),
-            language_public_parameters,
+            enc_dl_public_parameters,
         )?;
 
         // Create (k_i, η^i_3) tuples
@@ -519,7 +519,7 @@ where
                 GroupElement,
                 EncryptionKey,
             >,
-        >::generate_witnesses(witnesses, &language_public_parameters, rng)?;
+        >::generate_witnesses(witnesses, &enc_dl_public_parameters, rng)?;
 
         // === Create EncDL commitment round party ===
         //
@@ -547,7 +547,7 @@ where
             >::new_session(
                 self.party_id,
                 self.parties.clone(),
-                language_public_parameters,
+                enc_dl_public_parameters,
                 self.protocol_context.clone(),
                 witnesses,
                 rng,

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -306,9 +306,7 @@ where
         >::new::<SCALAR_LIMBS, GroupElement, EncryptionKey>(
             self.scalar_group_public_parameters.clone(),
             self.encryption_scheme_public_parameters.clone(),
-
-            // = ct_key = AHE.Enc(x_B) (see Protocol 4, step 2e/f)
-            self.encrypted_secret_key_share.value(),
+            self.encrypted_secret_key_share.value(), // = ct_key = AHE.Enc(x_B) (see Protocol 4, step 2e/f)
             encrypted_secret_key_share_upper_bound,
         );
         let enc_dh_public_parameters = EnhancedPublicParameters::<
@@ -473,9 +471,7 @@ where
                 self.scalar_group_public_parameters.clone(),
                 self.group_public_parameters.clone(),
                 self.encryption_scheme_public_parameters.clone(),
-
-                // = G (Protocol 5, step 2a (ii))
-                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters),
+                GroupElement::generator_value_from_public_parameters(&self.group_public_parameters), // = G (Protocol 5, step 2a (ii))
             );
         let enc_dl_public_parameters = EnhancedPublicParameters::<
             SOUND_PROOFS_REPETITIONS,

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -143,7 +143,7 @@ where
     /// This function implements step 2a of Protocol 5 (Presign):
     /// Verifies commitment and zk-proof for K_A, samples γ_i and k_i, and
     /// prepares computation of ct^i_1, ct^i_2 and ct^i_3, and their zk-proofs.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -140,7 +140,9 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
-    /// This function implements step 2a of Protocol 5 (Presign)
+    /// This function implements step 2a of Protocol 5 (Presign):
+    /// Verifies commitment and zk-proof for K_A, samples γ_i and k_i, and
+    /// prepares computation of ct^i_1, ct^i_2 and ct^i_3, and their zk-proofs.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Note: this function operates on batches; the annotations are written as

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -307,7 +307,7 @@ where
             self.encryption_scheme_public_parameters.clone(),
 
             // = ct_key = AHE.Enc(x_B) (see Protocol 4, step 2e/f)
-            self.encrypted_secret_key_share.value(), 
+            self.encrypted_secret_key_share.value(),
             encrypted_secret_key_share_upper_bound,
         );
         let enc_dh_public_parameters = EnhancedPublicParameters::<
@@ -391,7 +391,7 @@ where
         // By calling `commit_statements_and_statement_mask` on this party,
         // ct^i_1 and ct^i_2 are created.
         //
-        // sources: 
+        // sources:
         // --------
         // maurer::aggregation::commitment_round::commit_statements_and_statement_mask.
         // ct^i_1, ct^i_2 = enhanced_maurer::Language::homomorphose(witnesses, &enc_dl_public_parameters).
@@ -516,26 +516,26 @@ where
         // - [unbounded witness]     uw_i = η^i_{mask_3}
         //
         let witnesses = EnhancedLanguage::<
-        SOUND_PROOFS_REPETITIONS,
-        RANGE_CLAIMS_PER_SCALAR,
-        COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
-        RangeProof,
-        UnboundedEncDLWitness,
-        encryption_of_discrete_log::Language<
-        PLAINTEXT_SPACE_SCALAR_LIMBS,
-        SCALAR_LIMBS,
-        GroupElement,
-        EncryptionKey,
-        >,
+            SOUND_PROOFS_REPETITIONS,
+            RANGE_CLAIMS_PER_SCALAR,
+            COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
+            RangeProof,
+            UnboundedEncDLWitness,
+            encryption_of_discrete_log::Language<
+                PLAINTEXT_SPACE_SCALAR_LIMBS,
+                SCALAR_LIMBS,
+                GroupElement,
+                EncryptionKey,
+            >,
         >::generate_witnesses(witnesses, &enc_dl_public_parameters, rng)?;
-        
-        // === Prepare ct^i_3 computation ===      
+
+        // === Prepare ct^i_3 computation ===
         // Protocol 5, step 2a (iii) C
         //
         // By calling `commit_statements_and_statement_mask` on this party,
         // ct^i_3 is created.
         //
-        // sources: 
+        // sources:
         // --------
         // maurer::aggregation::commitment_round::commit_statements_and_statement_mask.
         // ct^i_3 = enhanced_maurer::Language::homomorphose(witnesses, &enc_dl_public_parameters).

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -424,10 +424,6 @@ where
 
         // === Sample k_i ===
         // Protocol 5, step 2a (ii)
-        //
-        //           !!! WARNING !!!
-        // This uses the same randomness as γ_i.
-        //           !!! WARNING !!!
         let shares_of_signature_nonce_shares_witnesses = masks_shares
             .clone()
             .into_iter()

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -140,9 +140,8 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
-    /// This function implements Protocol 5, step 2a of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 2a of Protocol 5 (Presign)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.

--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -268,7 +268,7 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
-        // === Sample η^i_1's ===
+        // === Sample η^i_{mask_1}'s ===
         // Protocol 5, 2a (iii)
         let masks_encryption_randomness = EncryptionKey::RandomnessSpaceGroupElement::sample_batch(
             self.encryption_scheme_public_parameters
@@ -277,7 +277,7 @@ where
             rng,
         )?;
 
-        // === Sample η^i_2's ===
+        // === Sample η^i_{mask_2}'s ===
         // Protocol 5, 2a (iii)
         let masked_key_share_encryption_randomness =
             EncryptionKey::RandomnessSpaceGroupElement::sample_batch(
@@ -334,7 +334,7 @@ where
             enc_dh_public_parameters,
         )?;
 
-        // Create (γ_i, η^i_1, η^i_2) tuples
+        // Create (γ_i, η^i_{mask_1}, η^i_{mask_2}) tuples
         let witnesses = mask_shares_witnesses
             .clone()
             .into_iter()
@@ -364,10 +364,10 @@ where
         // TODO: use izip! instead:
         // https://stackoverflow.com/questions/29669287/how-can-i-zip-more-than-two-iterators
 
-        // Map (γ_i, η^i_1, η^i_2) tuples to tuples of the form
+        // Map (γ_i, η^i_{mask_1}, η^i_{mask_2}) tuples to tuples of the form
         // - [commitment message]    cm_i = decomposed γ_i
         // - [commitment randomness] cr_i = fresh random sampled value
-        // - [unbounded witness]     uw_i = (η^i_1, η^i_2)
+        // - [unbounded witness]     uw_i = (η^i_{mask_1}, η^i_{mask_2})
         let witnesses = EnhancedLanguage::<
             SOUND_PROOFS_REPETITIONS,
             RANGE_CLAIMS_PER_SCALAR,
@@ -443,7 +443,7 @@ where
             })
             .collect::<group::Result<Vec<_>>>()?;
 
-        // === Sample η^i_3's ===
+        // === Sample η^i_{mask_3}'s ===
         // Protocol 5, step 2a (ii)
         let shares_of_signature_nonce_shares_encryption_randomness =
             EncryptionKey::RandomnessSpaceGroupElement::sample_batch(
@@ -497,7 +497,7 @@ where
             enc_dl_public_parameters,
         )?;
 
-        // Create (k_i, η^i_3) tuples
+        // Create (k_i, η^i_{mask_3}) tuples
         let witnesses: Vec<_> = shares_of_signature_nonce_shares_witnesses
             .clone()
             .into_iter()
@@ -505,10 +505,10 @@ where
             .map(|(nonce_share, encryption_randomness)| (nonce_share, encryption_randomness).into())
             .collect();
 
-        // Map (k_i, η^i_3) tuples to tuples of the form
+        // Map (k_i, η^i_{mask_3}) tuples to tuples of the form
         // - [commitment message]    cm_i = decomposed k_i
         // - [commitment randomness] cr_i = fresh random sampled value
-        // - [unbounded witness]     uw_i = η^i_3
+        // - [unbounded witness]     uw_i = η^i_{mask_3}
         //
         let witnesses = EnhancedLanguage::<
         SOUND_PROOFS_REPETITIONS,

--- a/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
@@ -99,7 +99,7 @@ where
 {
     /// This function implements step 2b of Protocol 5 (Presign):
     /// Prepares computation of ct^i_4 and its zk-proof.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.

--- a/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
@@ -97,7 +97,8 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
-    /// This function implements step 2b of Protocol 5 (Presign)
+    /// This function implements step 2b of Protocol 5 (Presign):
+    /// Prepares computation of ct^i_4 and its zk-proof.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Note: this function operates on batches; the annotations are written as

--- a/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
@@ -152,7 +152,7 @@ where
             .map(|statement| statement.encrypted_multiplicand().clone())
             .collect();
 
-        // === Sample η^i_4 ===
+        // === Sample η^i_{mask_4} ===
         // Protocol 5, 2a (iii)
         let masked_nonce_encryption_randomness =
             EncryptionKey::RandomnessSpaceGroupElement::sample_batch(
@@ -177,7 +177,7 @@ where
                 |(
                     // = ct_1
                     encrypted_mask,
-                    // = (k_i, (η^i_3, η^i_4))
+                    // = (k_i, (η^i_{mask_3}, η^i_{mask_4}))
                     (nonce, (nonces_encryption_randomness, masked_nonces_encryption_randomness)),
                 )| {
                     // Generate EncDH public parameters
@@ -225,10 +225,10 @@ where
                         enc_dh_public_parameters,
                     )?;
 
-                    // map (k_i, η^i_3, η^i_4) to a tuple with
+                    // map (k_i, η^i_{mask_3}, η^i_{mask_4}) to a tuple with
                     // - [commitment message]    cm_i = decomposed k_i
                     // - [commitment randomness] cr_i = randomly sampled value
-                    // - [unbounded witness]     uw_i = (η^i_3, η^i_4)
+                    // - [unbounded witness]     uw_i = (η^i_{mask_3}, η^i_{mask_4})
                     EnhancedLanguage::<
                         SOUND_PROOFS_REPETITIONS,
                         RANGE_CLAIMS_PER_SCALAR,
@@ -244,8 +244,8 @@ where
                     >::generate_witness(
                         (
                             nonce, // = k_i
-                            nonces_encryption_randomness, // = η^i_3
-                            masked_nonces_encryption_randomness, // = η^i_4
+                            nonces_encryption_randomness, // = η^i_{mask_3}
+                            masked_nonces_encryption_randomness, // = η^i_{mask_4}
                         )
                             .into(),
                         &enc_dh_public_parameters,

--- a/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
@@ -97,9 +97,8 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
-    /// This function implements Protocol 5, step 2b of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 2b of Protocol 5 (Presign)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Note: this function operates on batches; the annotations are written as
     /// if the batch size equals 1.

--- a/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
@@ -243,8 +243,8 @@ where
                         >,
                     >::generate_witness(
                         (
-                            nonce, // = k_i
-                            nonces_encryption_randomness, // = η^i_{mask_3}
+                            nonce,                               // = k_i
+                            nonces_encryption_randomness,        // = η^i_{mask_3}
                             masked_nonces_encryption_randomness, // = η^i_{mask_4}
                         )
                             .into(),
@@ -259,7 +259,7 @@ where
                         // By calling `commit_statements_and_statement_mask` on this party,
                         // ct^i_4 is created.
                         //
-                        // sources: 
+                        // sources:
                         // --------
                         // maurer::aggregation::commitment_round::commit_statements_and_statement_mask.
                         // ct^i_4 = enhanced_maurer::Language::homomorphose(witnesses, &enc_dl_public_parameters).

--- a/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
@@ -100,6 +100,9 @@ where
     /// This function implements Protocol 5, step 2b of the
     /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
     /// src: https://eprint.iacr.org/2024/253
+    ///
+    /// Note: this function operates on batches; the annotations are written as
+    /// if the batch size equals 1.
     pub fn initialize_proof_aggregation(
         self,
         masks_and_encrypted_masked_key_share: Vec<
@@ -136,9 +139,6 @@ where
             >,
         >,
     > {
-        // Note: this function works in batches; the annotations are written as
-        // if the batch has size = 1.
-
         let batch_size = encrypted_nonce_shares_and_public_shares.len();
         if masks_and_encrypted_masked_key_share.len() != batch_size {
             return Err(Error::InvalidParameters);
@@ -180,7 +180,7 @@ where
                     // = (k_i, (η^i_{mask_3}, η^i_{mask_4}))
                     (nonce, (nonces_encryption_randomness, masked_nonces_encryption_randomness)),
                 )| {
-                    // Generate EncDH public parameters
+                    // Construct EncDH public parameters
                     let encrypted_mask_upper_bound = composed_witness_upper_bound::<
                         RANGE_CLAIMS_PER_SCALAR,
                         PLAINTEXT_SPACE_SCALAR_LIMBS,

--- a/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_nonces_round.rs
@@ -178,7 +178,7 @@ where
                     >()?;
 
                     // Generate EncDH public parameters
-                    let language_public_parameters = encryption_of_tuple::PublicParameters::<
+                    let enc_dh_public_parameters = encryption_of_tuple::PublicParameters::<
                         PLAINTEXT_SPACE_SCALAR_LIMBS,
                         SCALAR_LIMBS,
                         GroupElement,
@@ -189,7 +189,7 @@ where
                         encrypted_mask.value(),
                         encrypted_mask_upper_bound,
                     );
-                    let language_public_parameters = EnhancedPublicParameters::<
+                    let enc_dh_public_parameters = EnhancedPublicParameters::<
                         SOUND_PROOFS_REPETITIONS,
                         RANGE_CLAIMS_PER_SCALAR,
                         COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
@@ -213,7 +213,7 @@ where
                     >(
                         self.unbounded_encdh_witness_public_parameters.clone(),
                         self.range_proof_public_parameters.clone(),
-                        language_public_parameters,
+                        enc_dh_public_parameters,
                     )?;
 
                     // map (ct_1, η^i_4)'s to tuples with
@@ -239,7 +239,7 @@ where
                             masked_nonces_encryption_randomness,
                         )
                             .into(),
-                        &language_public_parameters,
+                        &enc_dh_public_parameters,
                         rng,
                     )
                     .map_err(Error::from)
@@ -269,7 +269,7 @@ where
                         >::new_session(
                             self.party_id,
                             self.parties.clone(),
-                            language_public_parameters,
+                            enc_dh_public_parameters,
                             self.protocol_context.clone(),
                             vec![witness],
                             rng,

--- a/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
+++ b/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
@@ -135,7 +135,7 @@ where
 {
     /// This function implements step 1 of Protocol 6 (Sign):
     /// Computes ct_A and constructs zk-proofs for it, R_B and (K_A, U_A, X_A).
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     ///
     /// Evaluate the encrypted partial signature.
     /// Note: `message` is a `Scalar` which must be a hash on the message bytes translated into a

--- a/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
+++ b/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
@@ -275,8 +275,8 @@ where
             &self.protocol_context,
             &language_public_parameters,
             vec![[
-                self.nonce_share, // = k_A
-                self.nonce_share_commitment_randomness, // = ρ_1
+                self.nonce_share,                               // = k_A
+                self.nonce_share_commitment_randomness,         // = ρ_1
                 nonce_share_by_key_share_commitment_randomness, // = ρ_2
             ]
             .into()],

--- a/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
+++ b/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
@@ -133,7 +133,8 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
-    /// This function implements step 1 of Protocol 6 (Sign)
+    /// This function implements step 1 of Protocol 6 (Sign):
+    /// Computes ct_A and constructs zk-proofs for it, R_B and (K_A, U_A, X_A).
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Evaluate the encrypted partial signature.
@@ -217,7 +218,7 @@ where
             self.scalar_group_public_parameters.clone(),
             self.group_public_parameters.clone(),
             commitment_scheme_public_parameters.clone(),
-            public_nonce.value(),
+            public_nonce.value(), // = R
         );
 
         // === Construct R_B proof ===

--- a/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
+++ b/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
@@ -334,8 +334,9 @@ where
             ),
         ];
 
-        // === Sample ??? ===
-        // ???????????????
+        // === Sample ω ===
+        // Required for secure evaluation of the DComEval function.
+        // See `homomorphic-encryption::AdditivelyHomomorphicEncryptionKey::securely_evaluate_linear_combination_with_randomness`
         let mask = EncryptionKey::sample_mask_for_secure_function_evaluation(
             &ciphertexts_and_upper_bounds,
             &self.encryption_scheme_public_parameters,
@@ -363,7 +364,7 @@ where
         ]
         .into();
 
-        // = (A, ρ, ???, η)
+        // = (A, ρ, ω, η)
         let witness = (
             coefficients,
             commitment_randomness,

--- a/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
+++ b/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
@@ -133,9 +133,8 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
-    /// This function implements Protocol 6, step 1 of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 1 of Protocol 6 (Sign)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// Evaluate the encrypted partial signature.
     /// Note: `message` is a `Scalar` which must be a hash on the message bytes translated into a

--- a/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
+++ b/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
@@ -133,6 +133,10 @@ where
         >,
     Uint<PLAINTEXT_SPACE_SCALAR_LIMBS>: Encoding,
 {
+    /// This function implements Protocol 6, step 1 of the
+    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
+    /// src: https://eprint.iacr.org/2024/253
+    ///
     /// Evaluate the encrypted partial signature.
     /// Note: `message` is a `Scalar` which must be a hash on the message bytes translated into a
     /// 32-byte number.
@@ -188,23 +192,23 @@ where
         >,
         signature_verification_round::Party<SCALAR_LIMBS, GroupElement>,
     )> {
+        // = (k_A)^{-1}
         let inverted_nonce_share = self.nonce_share.invert();
-
         if inverted_nonce_share.is_none().into() {
             // This has negligible probability of failing.
             return Err(crate::Error::InternalError);
         }
-
         let inverted_nonce_share = inverted_nonce_share.unwrap();
 
-        let public_nonce = inverted_nonce_share * self.decentralized_party_nonce_public_share; // $R$
+        // = R
+        let public_nonce = inverted_nonce_share * self.decentralized_party_nonce_public_share;
 
+        // Generate DComDL public parameters
         let commitment_scheme_public_parameters =
             pedersen::PublicParameters::derive::<SCALAR_LIMBS, GroupElement>(
                 self.scalar_group_public_parameters.clone(),
                 self.group_public_parameters.clone(),
             )?;
-
         let language_public_parameters = committment_of_discrete_log::PublicParameters::new::<
             SCALAR_LIMBS,
             GroupElement::Scalar,
@@ -217,6 +221,8 @@ where
             public_nonce.value(),
         );
 
+        // === Generate DComDL proof ===
+        // Protocol 6, step 1e, dash 1
         let (public_nonce_proof, _) = maurer::Proof::<
             SOUND_PROOFS_REPETITIONS,
             committment_of_discrete_log::Language<
@@ -229,13 +235,16 @@ where
         >::prove(
             &self.protocol_context,
             &language_public_parameters,
-            vec![[self.nonce_share, self.nonce_share_commitment_randomness].into()],
+            vec![[self.nonce_share, self.nonce_share_commitment_randomness].into()], // = [k_A, ρ_1]
             rng,
         )?;
 
+        // === Sample ρ_2 ===
+        // Protocol 6, step 1b
         let nonce_share_by_key_share_commitment_randomness =
             GroupElement::Scalar::sample(&self.scalar_group_public_parameters, rng)?;
 
+        // Generate DComRatio public parameters
         let language_public_parameters =
             discrete_log_ratio_of_committed_values::PublicParameters::new::<
                 SCALAR_LIMBS,
@@ -248,6 +257,8 @@ where
                 self.public_key_share,
             );
 
+        // === Generate DComRatio proof ===
+        // Protocol 6, step 1e, dash 2
         let (nonce_share_by_key_share_proof, statement) = maurer::Proof::<
             SOUND_PROOFS_REPETITIONS,
             discrete_log_ratio_of_committed_values::Language<
@@ -267,26 +278,33 @@ where
             .into()],
             rng,
         )?;
-
         let statement = statement.first().ok_or(crate::Error::InternalError)?;
 
+        // = U_A
         let nonce_share_by_key_share_commitment =
             statement.altered_base_committment_of_discrete_log().clone();
 
-        let nonce_x_coordinate = public_nonce.x(); // $r$
+        // = r
+        let nonce_x_coordinate = public_nonce.x();
 
+        // = a_1
         let first_coefficient = (nonce_x_coordinate * self.nonce_share * self.secret_key_share)
-            + (message * self.nonce_share); // $a1$
+            + (message * self.nonce_share);
 
+        // = r * ρ_2 + m * ρ_1
         let first_coefficient_commitment_randomness = (nonce_x_coordinate
             * nonce_share_by_key_share_commitment_randomness)
             + (message * self.nonce_share_commitment_randomness);
 
-        let second_coefficient = nonce_x_coordinate * self.nonce_share; // $a2$
+        // = a_2
+        let second_coefficient = nonce_x_coordinate * self.nonce_share;
 
+        // = r * ρ_1
         let second_coefficient_commitment_randomness =
             nonce_x_coordinate * self.nonce_share_commitment_randomness;
 
+        // === Sample η ===
+        // Protocol 6, step 1d
         let partial_signature_encryption_randomness =
             EncryptionKey::RandomnessSpaceGroupElement::sample(
                 self.encryption_scheme_public_parameters
@@ -300,7 +318,6 @@ where
             COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
             RangeProof,
         >()?;
-
         let encrypted_masked_key_share_upper_bound: Option<_> = composed_witness_upper_bound::<
             RANGE_CLAIMS_PER_SCALAR,
             PLAINTEXT_SPACE_SCALAR_LIMBS,
@@ -309,7 +326,6 @@ where
         >()?
         .checked_mul(&encrypted_mask_upper_bound)
         .into();
-
         let ciphertexts_and_upper_bounds = [
             (self.encrypted_mask, encrypted_mask_upper_bound),
             (
@@ -318,18 +334,17 @@ where
             ),
         ];
 
+        // === Sample ??? ===
+        // ???????????????
         let mask = EncryptionKey::sample_mask_for_secure_function_evaluation(
             &ciphertexts_and_upper_bounds,
             &self.encryption_scheme_public_parameters,
             rng,
         )?;
 
-        let ciphertexts_and_upper_bounds =
-            ciphertexts_and_upper_bounds.map(|(ct, upper_bound)| (ct.value(), upper_bound));
-
+        // = A (see DComEval language definition, Section 5.2)
         let coefficients: [Uint<SCALAR_LIMBS>; DIMENSION] =
             [first_coefficient, second_coefficient].map(|coefficient| coefficient.into());
-
         let coefficients: self_product::GroupElement<DIMENSION, _> = coefficients
             .map(|coefficient| {
                 EncryptionKey::PlaintextSpaceGroupElement::new(
@@ -341,12 +356,14 @@ where
             .flat_map_results()?
             .into();
 
+        // = ρ (see DComEval language definition, Section 5.2)
         let commitment_randomness: self_product::GroupElement<DIMENSION, _> = [
             first_coefficient_commitment_randomness,
             second_coefficient_commitment_randomness,
         ]
         .into();
 
+        // = (A, ρ, ???, η)
         let witness = (
             coefficients,
             commitment_randomness,
@@ -355,8 +372,10 @@ where
         )
             .into();
 
+        // Generate DComEval language parameters
+        let ciphertexts_and_upper_bounds =
+            ciphertexts_and_upper_bounds.map(|(ct, upper_bound)| (ct.value(), upper_bound));
         let commitment_scheme_public_parameters = commitment_scheme_public_parameters.into();
-
         let language_public_parameters = committed_linear_evaluation::PublicParameters::<
             PLAINTEXT_SPACE_SCALAR_LIMBS,
             SCALAR_LIMBS,
@@ -370,7 +389,6 @@ where
             commitment_scheme_public_parameters,
             ciphertexts_and_upper_bounds,
         );
-
         let language_public_parameters = EnhancedPublicParameters::<
             SOUND_PROOFS_REPETITIONS,
             NUM_RANGE_CLAIMS,
@@ -404,6 +422,8 @@ where
             language_public_parameters,
         )?;
 
+        // === Compute ct_A ===
+        // Protocol 6, step 1e, dash 3
         let witness = EnhancedLanguage::<
             SOUND_PROOFS_REPETITIONS,
             NUM_RANGE_CLAIMS,
@@ -420,7 +440,6 @@ where
                 EncryptionKey,
             >,
         >::generate_witness(witness, &language_public_parameters, rng)?;
-
         let (encrypted_partial_signature_proof, statement) = enhanced_maurer::Proof::<
             SOUND_PROOFS_REPETITIONS,
             NUM_RANGE_CLAIMS,
@@ -443,11 +462,10 @@ where
             vec![witness],
             rng,
         )?;
-
         let statement = statement.first().ok_or(crate::Error::InternalError)?;
 
         let encrypted_partial_signature_range_proof_commitment = statement.range_proof_commitment();
-        let encrypted_partial_signature = statement.language_statement().evaluated_ciphertext();
+        let encrypted_partial_signature = statement.language_statement().evaluated_ciphertext(); // = ct_A
         let coefficient_commitments: &[_; DIMENSION] =
             statement.language_statement().commitments().into();
 

--- a/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
+++ b/src/sign/centralized_party/signature_homomorphic_evaluation_round.rs
@@ -424,7 +424,7 @@ where
         )?;
 
         // === Compute ct_A ===
-        // Protocol 6, step 1e, dash 3
+        // Protocol 6, step 1d and step 1e, dash 3
         let witness = EnhancedLanguage::<
             SOUND_PROOFS_REPETITIONS,
             NUM_RANGE_CLAIMS,

--- a/src/sign/centralized_party/signature_verification_round.rs
+++ b/src/sign/centralized_party/signature_verification_round.rs
@@ -22,10 +22,10 @@ impl<
         signature_s: GroupElement::Scalar,
     ) -> crate::Result<()> {
         verify_signature(
-            nonce_x_coordinate,
-            signature_s,
-            self.message,
-            self.public_key,
+            nonce_x_coordinate, // = r
+            signature_s, // = s
+            self.message, // = m
+            self.public_key, // = X
         )?;
 
         Ok(())

--- a/src/sign/centralized_party/signature_verification_round.rs
+++ b/src/sign/centralized_party/signature_verification_round.rs
@@ -23,9 +23,9 @@ impl<
     ) -> crate::Result<()> {
         verify_signature(
             nonce_x_coordinate, // = r
-            signature_s, // = s
-            self.message, // = m
-            self.public_key, // = X
+            signature_s,        // = s
+            self.message,       // = m
+            self.public_key,    // = X
         )?;
 
         Ok(())

--- a/src/sign/decentralized_party/signature_partial_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_partial_decryption_round.rs
@@ -212,32 +212,39 @@ where
             rng,
         )?;
 
+        // = ct_A
         let encrypted_partial_signature = EncryptionKey::CiphertextSpaceGroupElement::new(
             public_nonce_encrypted_partial_signature_and_proof.encrypted_partial_signature,
             self.encryption_scheme_public_parameters
                 .ciphertext_space_public_parameters(),
         )?;
 
+        // = R
         let public_nonce = GroupElement::new(
             public_nonce_encrypted_partial_signature_and_proof.public_nonce,
             &self.group_public_parameters,
-        )?; // $R$
+        )?;
 
-        let nonce_x_coordinate = public_nonce.x(); // $r$
+        // = r
+        let nonce_x_coordinate = public_nonce.x();
 
+        // === Compute pt_A ===
+        // Protocol 6, step 2c
         let partial_signature_decryption_share = Option::from(
             self.decryption_key_share
                 .generate_decryption_share_semi_honest(
-                    &encrypted_partial_signature,
+                    &encrypted_partial_signature, // = ct_A
                     &self.decryption_key_share_public_parameters,
                 ),
         )
         .ok_or(Error::InternalError)?;
 
+        // === Compute pt_4 ===
+        // Protocol 6, step 2c
         let masked_nonce_decryption_share = Option::from(
             self.decryption_key_share
                 .generate_decryption_share_semi_honest(
-                    &self.encrypted_masked_nonce_share,
+                    &self.encrypted_masked_nonce_share, // = ct_4
                     &self.decryption_key_share_public_parameters,
                 ),
         )
@@ -262,6 +269,9 @@ where
         ))
     }
 
+    /// This function implements Protocol 6, step 2a of the
+    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
+    /// src: https://eprint.iacr.org/2024/253
     #[allow(clippy::too_many_arguments)]
     fn verify_encrypted_signature_parts_prehash_inner(
         message: GroupElement::Scalar,
@@ -320,19 +330,21 @@ where
         centralized_party_nonce_share_commitment: GroupElement,
         rng: &mut impl CryptoRngCore,
     ) -> crate::Result<()> {
+        // = R
         let public_nonce = GroupElement::new(
             public_nonce_encrypted_partial_signature_and_proof.public_nonce,
             group_public_parameters,
-        )?; // $R$
+        )?;
 
-        let nonce_x_coordinate = public_nonce.x(); // $r$
+        // = r
+        let nonce_x_coordinate = public_nonce.x();
 
+        // Gather DComDL public parameters
         let commitment_scheme_public_parameters =
             pedersen::PublicParameters::derive::<SCALAR_LIMBS, GroupElement>(
                 scalar_group_public_parameters.clone(),
                 group_public_parameters.clone(),
             )?;
-
         let language_public_parameters = committment_of_discrete_log::PublicParameters::new::<
             SCALAR_LIMBS,
             GroupElement::Scalar,
@@ -345,18 +357,21 @@ where
             public_nonce_encrypted_partial_signature_and_proof.public_nonce,
         );
 
+        // === Verify DComDL proof ===
+        // Protocol 6, step 2a, dash 1
         public_nonce_encrypted_partial_signature_and_proof
             .public_nonce_proof
             .verify(
                 protocol_context,
                 &language_public_parameters,
                 vec![[
-                    centralized_party_nonce_share_commitment.clone(),
-                    nonce_public_share.clone(),
+                    centralized_party_nonce_share_commitment.clone(), // = K_A
+                    nonce_public_share.clone(),                       // = R_B
                 ]
                 .into()],
             )?;
 
+        // Gather DComRatio language parameters
         let language_public_parameters =
             discrete_log_ratio_of_committed_values::PublicParameters::new::<
                 SCALAR_LIMBS,
@@ -369,30 +384,33 @@ where
                 centralized_party_public_key_share.clone(),
             );
 
+        // = U_A
         let nonce_share_by_key_share_commitment = GroupElement::new(
             public_nonce_encrypted_partial_signature_and_proof.nonce_share_by_key_share_commitment,
             group_public_parameters,
         )?;
 
+        // === Verify DComRatio proof ===
+        // Protocol 6, step 2a, dash 2
         public_nonce_encrypted_partial_signature_and_proof
             .nonce_share_by_key_share_proof
             .verify(
                 protocol_context,
                 &language_public_parameters,
                 vec![[
-                    centralized_party_nonce_share_commitment.clone(),
-                    nonce_share_by_key_share_commitment.clone(),
+                    centralized_party_nonce_share_commitment.clone(), // = K_A
+                    nonce_share_by_key_share_commitment.clone(),      // = U_A
                 ]
                 .into()],
             )?;
 
+        // Generate DComEval language parameters
         let encrypted_mask_upper_bound = composed_witness_upper_bound::<
             RANGE_CLAIMS_PER_SCALAR,
             PLAINTEXT_SPACE_SCALAR_LIMBS,
             COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
             RangeProof,
         >()?;
-
         let encrypted_masked_key_share_upper_bound: Option<_> = composed_witness_upper_bound::<
             RANGE_CLAIMS_PER_SCALAR,
             PLAINTEXT_SPACE_SCALAR_LIMBS,
@@ -401,18 +419,15 @@ where
         >()?
         .checked_mul(&encrypted_mask_upper_bound)
         .into();
-
         let ciphertexts_and_upper_bounds = [
-            (encrypted_mask.clone(), encrypted_mask_upper_bound),
+            (encrypted_mask.clone(), encrypted_mask_upper_bound), // = (ct_1, ...)
             (
-                encrypted_masked_key_share.clone(),
+                encrypted_masked_key_share.clone(), // = ct_2
                 encrypted_masked_key_share_upper_bound.ok_or(Error::InvalidPublicParameters)?,
             ),
         ]
         .map(|(ct, upper_bound)| (ct.value(), upper_bound));
-
         let commitment_scheme_public_parameters = commitment_scheme_public_parameters.into();
-
         let language_public_parameters = committed_linear_evaluation::PublicParameters::<
             PLAINTEXT_SPACE_SCALAR_LIMBS,
             SCALAR_LIMBS,
@@ -426,7 +441,6 @@ where
             commitment_scheme_public_parameters,
             ciphertexts_and_upper_bounds,
         );
-
         let language_public_parameters = EnhancedPublicParameters::<
             SOUND_PROOFS_REPETITIONS,
             NUM_RANGE_CLAIMS,
@@ -460,11 +474,14 @@ where
             language_public_parameters,
         )?;
 
+        // ct_A
         let encrypted_partial_signature = EncryptionKey::CiphertextSpaceGroupElement::new(
             public_nonce_encrypted_partial_signature_and_proof.encrypted_partial_signature,
             encryption_scheme_public_parameters.ciphertext_space_public_parameters(),
         )?;
 
+        // === Verify DComEval proof ===
+        // Protocol 6, step 2a, dash 3
         let range_proof_commitment = proof::range::CommitmentSchemeCommitmentSpaceGroupElement::<
             COMMITMENT_SCHEME_MESSAGE_SPACE_SCALAR_LIMBS,
             NUM_RANGE_CLAIMS,
@@ -476,7 +493,6 @@ where
                 .commitment_scheme_public_parameters()
                 .commitment_space_public_parameters(),
         )?;
-
         public_nonce_encrypted_partial_signature_and_proof
             .encrypted_partial_signature_proof
             .verify(
@@ -580,14 +596,17 @@ where
             group_public_parameters,
         )?;
 
+        // = R_B
         let nonce_public_share =
             GroupElement::new(presign.nonce_public_share, group_public_parameters)?;
 
+        // = ct_1
         let encrypted_mask = EncryptionKey::CiphertextSpaceGroupElement::new(
             presign.encrypted_mask,
             encryption_scheme_public_parameters.ciphertext_space_public_parameters(),
         )?;
 
+        // = ct_2
         let encrypted_masked_key_share = EncryptionKey::CiphertextSpaceGroupElement::new(
             presign.encrypted_masked_key_share,
             encryption_scheme_public_parameters.ciphertext_space_public_parameters(),
@@ -659,19 +678,23 @@ where
             &group_public_parameters,
         )?;
 
+        // = R_B
         let nonce_public_share =
             GroupElement::new(presign.nonce_public_share, &group_public_parameters)?;
 
+        // = ct_1
         let encrypted_mask = EncryptionKey::CiphertextSpaceGroupElement::new(
             presign.encrypted_mask,
             encryption_scheme_public_parameters.ciphertext_space_public_parameters(),
         )?;
 
+        // = ct_2
         let encrypted_masked_key_share = EncryptionKey::CiphertextSpaceGroupElement::new(
             presign.encrypted_masked_key_share,
             encryption_scheme_public_parameters.ciphertext_space_public_parameters(),
         )?;
 
+        // = ct_4
         let encrypted_masked_nonce_share = EncryptionKey::CiphertextSpaceGroupElement::new(
             presign.encrypted_masked_nonce_share,
             encryption_scheme_public_parameters.ciphertext_space_public_parameters(),

--- a/src/sign/decentralized_party/signature_partial_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_partial_decryption_round.rs
@@ -404,7 +404,7 @@ where
                 .into()],
             )?;
 
-        // Generate DComEval language parameters
+        // Construct L_DComEval language parameters
         let encrypted_mask_upper_bound = composed_witness_upper_bound::<
             RANGE_CLAIMS_PER_SCALAR,
             PLAINTEXT_SPACE_SCALAR_LIMBS,

--- a/src/sign/decentralized_party/signature_partial_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_partial_decryption_round.rs
@@ -271,7 +271,7 @@ where
 
     /// This function implements step 2a of Protocol 6 (Sign):
     /// Verifies zk-proofs of R_B, (K_A, U_A, X_A) and ct_A.
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     #[allow(clippy::too_many_arguments)]
     fn verify_encrypted_signature_parts_prehash_inner(
         message: GroupElement::Scalar,

--- a/src/sign/decentralized_party/signature_partial_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_partial_decryption_round.rs
@@ -269,9 +269,8 @@ where
         ))
     }
 
-    /// This function implements Protocol 6, step 2a of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 2a of Protocol 6 (Sign)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     #[allow(clippy::too_many_arguments)]
     fn verify_encrypted_signature_parts_prehash_inner(
         message: GroupElement::Scalar,

--- a/src/sign/decentralized_party/signature_partial_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_partial_decryption_round.rs
@@ -269,7 +269,8 @@ where
         ))
     }
 
-    /// This function implements step 2a of Protocol 6 (Sign)
+    /// This function implements step 2a of Protocol 6 (Sign):
+    /// Verifies zk-proofs of R_B, (K_A, U_A, X_A) and ct_A.
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     #[allow(clippy::too_many_arguments)]
     fn verify_encrypted_signature_parts_prehash_inner(
@@ -356,7 +357,7 @@ where
             public_nonce_encrypted_partial_signature_and_proof.public_nonce,
         );
 
-        // === Verify DComDL proof ===
+        // === Verify (K_A, R_B) proof ===
         // Protocol 6, step 2a, dash 1
         public_nonce_encrypted_partial_signature_and_proof
             .public_nonce_proof

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -70,7 +70,7 @@ where
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
         // Check whether all involved decrypters submitted their ct_A and ct_4 shares.
         let decrypters: HashSet<_> = lagrange_coefficients.clone().into_keys().collect();
-        if decrypters.len() != usize::from(self.threshold) 
+        if decrypters.len() != usize::from(self.threshold)
             || decrypters
                 != partial_signature_decryption_shares // ct_A shares
                     .keys()

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -50,6 +50,10 @@ impl<
 where
     Error: From<DecryptionKeyShare::Error>,
 {
+    /// This function implements Protocol 6, step 2 of the
+    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
+    /// src: https://eprint.iacr.org/2024/253
+    ///
     /// The designated threshold decryption party logic, which performs the amortized heavy-lifting
     /// $$ O(n) $$ public decryption logic. An honest party would verify the signature and
     /// output it if and only if it is valid, otherwise (i.e. when
@@ -80,6 +84,14 @@ where
             return Err(Error::InvalidParameters);
         }
 
+        // = q
+        let group_order = GroupElement::Scalar::order_from_public_parameters(
+            &self.scalar_group_public_parameters,
+        );
+        let group_order =
+            Option::<_>::from(NonZero::new(group_order)).ok_or(Error::InternalError)?;
+
+        // = pt_A
         let partial_signature: Uint<PLAINTEXT_SPACE_SCALAR_LIMBS> =
             DecryptionKeyShare::combine_decryption_shares_semi_honest(
                 partial_signature_decryption_shares,
@@ -87,19 +99,13 @@ where
                 &self.decryption_key_share_public_parameters,
             )?
             .into();
-
-        let group_order = GroupElement::Scalar::order_from_public_parameters(
-            &self.scalar_group_public_parameters,
-        );
-
-        let group_order =
-            Option::<_>::from(NonZero::new(group_order)).ok_or(Error::InternalError)?;
-
         let partial_signature = GroupElement::Scalar::new(
             partial_signature.reduce(&group_order).into(),
             &self.scalar_group_public_parameters,
         )?;
 
+        // === Compute pt_4 ===
+        // Protocol 6, step 2c
         let masked_nonce: Uint<PLAINTEXT_SPACE_SCALAR_LIMBS> =
             DecryptionKeyShare::combine_decryption_shares_semi_honest(
                 masked_nonce_decryption_shares,
@@ -107,21 +113,30 @@ where
                 &self.decryption_key_share_public_parameters,
             )?
             .into();
-
         let masked_nonce = GroupElement::Scalar::new(
             masked_nonce.reduce(&group_order).into(),
             &self.scalar_group_public_parameters,
         )?;
 
+        // === Compute (pt_4)^{-1} ===
+        // Protocol 6, step 2c
+        // = (γ * k_B)^{-1}
         let inverted_masked_nonce = masked_nonce.invert();
-
         if inverted_masked_nonce.is_none().into() {
             return Err(Error::SignatureVerification);
         }
 
+        // === Compute s' ===
+        // Protocol 6, step 2c
+        //
+        // s' = pt_4^-1 * pt_A
+        //    = k * (rx + m)
         let signature_s = inverted_masked_nonce.unwrap() * partial_signature;
         let negated_signature_s = signature_s.neg();
 
+        // === Compute s ===
+        // Protocol 6, step 2c
+        // = min(s', q-s')
         // Attend to malleability.
         let signature_s = if negated_signature_s.value() < signature_s.value() {
             negated_signature_s
@@ -129,6 +144,7 @@ where
             signature_s
         };
 
+        // Verify signature (r, s) for (m, pk)
         verify_signature(
             self.nonce_x_coordinate,
             signature_s,

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -50,7 +50,8 @@ impl<
 where
     Error: From<DecryptionKeyShare::Error>,
 {
-    /// This function implements step 2 of Protocol 6 (Sign)
+    /// This function implements step 2 of Protocol 6 (Sign):
+    /// Computes signature (r, s) for (m, pk).
     /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// The designated threshold decryption party logic, which performs the amortized heavy-lifting

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -50,9 +50,8 @@ impl<
 where
     Error: From<DecryptionKeyShare::Error>,
 {
-    /// This function implements Protocol 6, step 2 of the
-    /// 2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC paper.
-    /// src: https://eprint.iacr.org/2024/253
+    /// This function implements step 2 of Protocol 6 (Sign)
+    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
     ///
     /// The designated threshold decryption party logic, which performs the amortized heavy-lifting
     /// $$ O(n) $$ public decryption logic. An honest party would verify the signature and

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -52,7 +52,7 @@ where
 {
     /// This function implements step 2 of Protocol 6 (Sign):
     /// Computes signature (r, s) for (m, pk).
-    /// src: https://eprint.iacr.org/archive/2024/253/20240217:153208
+    /// src: <https://eprint.iacr.org/archive/2024/253/20240217:153208>
     ///
     /// The designated threshold decryption party logic, which performs the amortized heavy-lifting
     /// $$ O(n) $$ public decryption logic. An honest party would verify the signature and

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -68,15 +68,16 @@ where
         partial_signature_decryption_shares: HashMap<PartyID, DecryptionKeyShare::DecryptionShare>,
         masked_nonce_decryption_shares: HashMap<PartyID, DecryptionKeyShare::DecryptionShare>,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
+        // Check whether all involved decrypters submitted their ct_A and ct_4 shares.
         let decrypters: HashSet<_> = lagrange_coefficients.clone().into_keys().collect();
-        if decrypters.len() != usize::from(self.threshold)
+        if decrypters.len() != usize::from(self.threshold) 
             || decrypters
-                != partial_signature_decryption_shares
+                != partial_signature_decryption_shares // ct_A shares
                     .keys()
                     .cloned()
                     .collect::<HashSet<_>>()
             || decrypters
-                != masked_nonce_decryption_shares
+                != masked_nonce_decryption_shares // ct_4 shares
                     .keys()
                     .cloned()
                     .collect::<HashSet<_>>()


### PR DESCRIPTION
This PR annotates the code in this crate with the variable names used to represent the same concepts in the "[2PC-MPC: Emulating Two Party ECDSA in Large-Scale MPC (v20240217)](https://eprint.iacr.org/archive/2024/253/20240217:153208)" paper.

To enhance the readability of the code, additionally, the order of some object instantiations was rearranged. Care was taken to ensure these rearrangements do not introduce flaws in the protocol execution. Still, this PR should be carefully examined to verify this claim.