### PR TITLE
Fix nonce reuse bug

### DIFF
--- a/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
+++ b/src/presign/decentralized_party/encrypted_masked_key_share_and_public_nonce_shares_round.rs
@@ -380,7 +380,18 @@ where
                 rng,
             )?;
 
-        let shares_of_signature_nonce_shares_witnesses = masks_shares
+        // ==================================
+        // Steps involving the EncDL language
+        // ==================================
+
+        // === Sample k_i ===
+        // Protocol 5, step 2a (ii)
+        let share_of_signature_nonce_share = GroupElement::Scalar::sample_batch(
+            &self.scalar_group_public_parameters,
+            batch_size,
+            rng,
+        )?;
+        let shares_of_signature_nonce_shares_witnesses = share_of_signature_nonce_share
             .clone()
             .into_iter()
             .map(|share_of_signature_nonce_share| {


### PR DESCRIPTION
This PR introduces a fix to the nonce-reuse bug found in the presign protocol.

_About the fix._
Although [the paper](https://eprint.iacr.org/2024/253) states that k_i must be sampled from Z*_q [[1]](https://eprint.iacr.org/2024/253.pdf#thm.5), the fix samples from Z_q instead and ignores the negligible chance that the sampled value is 0. Ultimately, if sum_i(k_i) = k_B = 0 mod q, the protocol would anyway abort [when inverting pt_4](https://github.com/erik-3milabs/2pc-mpc/blob/12601757ab3315d522cede22c699570d03dc71a5/src/sign/decentralized_party/signature_threshold_decryption_round.rs#L127).