### PR TITLE
chore!: Add a static signature verification function to `signature_threshold_decryption_round` party

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub enum Error {
     #[error("the other party maliciously attempted to bypass the commitment round by sending decommitment which does not match its commitment")]
     WrongDecommitment,
     #[error("the designated decrypting party behaved maliciously by not sending the honest decrypted values")]
-    MaliciousDesignatedDecryptingParty,
+    MaliciousDesignatedDecryptingParty(PartyID),
     #[error("signature failed to verify")]
     SignatureVerification,
     #[error("invalid public parameters")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub enum Error {
     #[error("the other party maliciously attempted to bypass the commitment round by sending decommitment which does not match its commitment")]
     WrongDecommitment,
     #[error("the designated decrypting party behaved maliciously by not sending the honest decrypted values")]
-    MaliciousDesignatedDecryptingParty(PartyID),
+    MaliciousDesignatedDecryptingParty,
     #[error("signature failed to verify")]
     SignatureVerification,
     #[error("invalid public parameters")]

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -407,7 +407,7 @@ pub(crate) mod tests {
         signature_threshold_decryption_round_parties.for_each(
             |(_, signature_threshold_decryption_round_party)| {
                 let res = signature_threshold_decryption_round_party
-                    .verify_decrypted_signature(signature_s);
+                    .verify_decrypted_signature_wrapper(signature_s);
 
                 if designated_sending_wrong_signature {
                     assert!(

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -832,8 +832,6 @@ pub(crate) mod tests {
 
         let decrypters: Vec<_> = decryption_key_shares.keys().cloned().collect();
 
-        let designated_decrypting_party_id = *decryption_key_shares.keys().next().unwrap();
-
         let paillier_encryption_key = tiresias::EncryptionKey::new(
             &decryption_key_share_public_parameters.encryption_scheme_public_parameters,
         )

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -971,7 +971,7 @@ pub(crate) mod tests {
                         // was invalid, even tho it wasn't.
                         matches!(
                         err,
-                            Error::MaliciousDesignatedDecryptingParty(party_id) if party_id == designated_decrypting_party_id
+                            Error::MaliciousDesignatedDecryptingParty if party_id == designated_decrypting_party_id
                             )
                     } else {
                         matches!(

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -377,7 +377,7 @@ pub(crate) mod tests {
             signature_threshold_decryption_round_parties.into_iter();
 
         // choose some party as the amortized threshold decryption party
-        let (designated_party_id, signature_threshold_decryption_round_party) =
+        let (_, signature_threshold_decryption_round_party) =
             signature_threshold_decryption_round_parties.next().unwrap();
 
         let now = measurement.start();

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -910,7 +910,6 @@ pub(crate) mod tests {
                         DecryptionKeyShare,
                     > {
                         threshold,
-                        designated_decrypting_party_id,
                         decryption_key_share,
                         decryption_key_share_public_parameters:
                             decryption_key_share_public_parameters.clone(),

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -407,13 +407,13 @@ pub(crate) mod tests {
         signature_threshold_decryption_round_parties.for_each(
             |(_, signature_threshold_decryption_round_party)| {
                 let res = signature_threshold_decryption_round_party
-                    .verify_decrypted_signature(signature_s, designated_party_id);
+                    .verify_decrypted_signature(signature_s);
 
                 if designated_sending_wrong_signature {
                     assert!(
                         matches!(
                             res.err().unwrap(),
-                            Error::MaliciousDesignatedDecryptingParty(party_id) if party_id == designated_party_id
+                            Error::SignatureVerification
                         ),
                         "Malicious designated decryption party which sends an invalid signature must be blamed"
                     );
@@ -969,10 +969,7 @@ pub(crate) mod tests {
                     if dos {
                         // Test the case where the designated party tried to DOS by saying signature
                         // was invalid, even tho it wasn't.
-                        matches!(
-                        err,
-                            Error::MaliciousDesignatedDecryptingParty if party_id == designated_decrypting_party_id
-                            )
+                        matches!(err, Error::SignatureVerification)
                     } else {
                         matches!(
                         err,

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -413,7 +413,7 @@ pub(crate) mod tests {
                     assert!(
                         matches!(
                             res.err().unwrap(),
-                            Error::SignatureVerification
+                            Error::MaliciousDesignatedDecryptingParty
                         ),
                         "Malicious designated decryption party which sends an invalid signature must be blamed"
                     );
@@ -969,7 +969,7 @@ pub(crate) mod tests {
                     if dos {
                         // Test the case where the designated party tried to DOS by saying signature
                         // was invalid, even tho it wasn't.
-                        matches!(err, Error::SignatureVerification)
+                        matches!(err, Error::MaliciousDesignatedDecryptingParty)
                     } else {
                         matches!(
                         err,

--- a/src/sign/decentralized_party/identifiable_abort/signature_partial_decryption_proof_round.rs
+++ b/src/sign/decentralized_party/identifiable_abort/signature_partial_decryption_proof_round.rs
@@ -32,7 +32,6 @@ pub struct Party<
     DecryptionKeyShare: AdditivelyHomomorphicDecryptionKeyShare<PLAINTEXT_SPACE_SCALAR_LIMBS, EncryptionKey>,
 > {
     pub(in crate::sign) threshold: PartyID,
-    pub(in crate::sign) designated_decrypting_party_id: PartyID,
     pub(in crate::sign) decryption_key_share: DecryptionKeyShare,
     pub(in crate::sign) decryption_key_share_public_parameters:
         DecryptionKeyShare::PublicParameters,
@@ -72,7 +71,6 @@ where
         let signature_partial_decryption_verification_round_party =
             signature_partial_decryption_verification_round::Party {
                 threshold: self.threshold,
-                designated_decrypting_party_id: self.designated_decrypting_party_id,
                 decryption_key_share_public_parameters: self.decryption_key_share_public_parameters,
                 encrypted_partial_signature: self.encrypted_partial_signature,
                 encrypted_masked_nonce_share: self.encrypted_masked_nonce_share,
@@ -93,7 +91,6 @@ where
         ProtocolContext: Clone + Serialize,
     >(
         threshold: PartyID,
-        designated_decrypting_party_id: PartyID,
         decryption_key_share: DecryptionKeyShare,
         decryption_key_share_public_parameters: DecryptionKeyShare::PublicParameters,
         presign: presign::decentralized_party::Presign<
@@ -194,7 +191,6 @@ where
 
         Ok(Self {
             threshold,
-            designated_decrypting_party_id,
             decryption_key_share,
             decryption_key_share_public_parameters,
             encrypted_partial_signature,

--- a/src/sign/decentralized_party/identifiable_abort/signature_partial_decryption_verification_round.rs
+++ b/src/sign/decentralized_party/identifiable_abort/signature_partial_decryption_verification_round.rs
@@ -18,7 +18,6 @@ pub struct Party<
     DecryptionKeyShare: AdditivelyHomomorphicDecryptionKeyShare<PLAINTEXT_SPACE_SCALAR_LIMBS, EncryptionKey>,
 > {
     pub(super) threshold: PartyID,
-    pub(super) designated_decrypting_party_id: PartyID,
     pub(super) decryption_key_share_public_parameters: DecryptionKeyShare::PublicParameters,
     pub(super) encrypted_partial_signature: EncryptionKey::CiphertextSpaceGroupElement,
     pub(super) encrypted_masked_nonce_share: EncryptionKey::CiphertextSpaceGroupElement,

--- a/src/sign/decentralized_party/identifiable_abort/signature_partial_decryption_verification_round.rs
+++ b/src/sign/decentralized_party/identifiable_abort/signature_partial_decryption_verification_round.rs
@@ -113,8 +113,6 @@ where
         )
         .err()
         .map(Error::from)
-        .unwrap_or(Error::MaliciousDesignatedDecryptingParty(
-            self.designated_decrypting_party_id,
-        ))
+        .unwrap_or(Error::MaliciousDesignatedDecryptingParty)
     }
 }

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -171,7 +171,7 @@ where
     }
 
     /// The lightweight $$ O(1) $$ threshold decryption logic, which simply verifies the output of
-    /// the decryption sent by the designated decrypting party. Returns a [`Error::SignatureVerification`]
+    /// the decryption sent by the designated decrypting party. Returns a [`Error::MaliciousDesignatedDecryptingParty`]
     /// in case of an invalid signature, and accepts otherwise.
     pub fn verify_decrypted_signature_internal(
         nonce_x_coordinate: GroupElement::Scalar,

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -162,36 +162,27 @@ where
     pub fn verify_decrypted_signature(
         self,
         signature_s: GroupElement::Scalar,
-        designated_decrypting_party_id: PartyID,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
         Self::verify_decrypted_signature_static(
             signature_s,
-            designated_decrypting_party_id,
             self.nonce_x_coordinate,
             self.message,
             self.public_key,
         )
     }
+
     /// The lightweight $$ O(1) $$ threshold decryption logic, which simply verifies the output of
-    /// the decryption sent by the designated decrypting party. Blames it in case of an invalid
-    /// signature, and accepts otherwise.
+    /// the decryption sent by the designated decrypting party. Returns a [`Error::SignatureVerification`]
+    /// in case of an invalid signature, and accepts otherwise.
     pub fn verify_decrypted_signature_static(
         signature_s: GroupElement::Scalar,
-        designated_decrypting_party_id: PartyID,
         nonce_x_coordinate: GroupElement::Scalar,
         message: GroupElement::Scalar,
         public_key: GroupElement,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
-        verify_signature(
-            nonce_x_coordinate,
-            signature_s,
-            message,
-            public_key,
-        )
-        .map_err(|_| Error::MaliciousDesignatedDecryptingParty(designated_decrypting_party_id))?;
+        verify_signature(nonce_x_coordinate, signature_s, message, public_key)
+            .map_err(|_| Error::SignatureVerification)?;
 
         Ok((nonce_x_coordinate, signature_s))
     }
-
-    //
 }

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -156,13 +156,13 @@ where
         Ok((self.nonce_x_coordinate, signature_s))
     }
 
-    /// A wrapper function for [`Self::verify_decrypted_signature_internal`] that uses self's
+    /// A wrapper function for [`Self::verify_decrypted_signature_wrapper`] that uses self's
     /// attributes to verify the decrypted signature.
     pub fn verify_decrypted_signature(
         self,
         signature_s: GroupElement::Scalar,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
-        Self::verify_decrypted_signature_internal(
+        Self::verify_decrypted_signature_wrapper(
             self.nonce_x_coordinate,
             signature_s,
             self.message,
@@ -173,7 +173,7 @@ where
     /// The lightweight $$ O(1) $$ threshold decryption logic, which simply verifies the output of
     /// the decryption sent by the designated decrypting party. Returns a [`Error::MaliciousDesignatedDecryptingParty`]
     /// in case of an invalid signature, and accepts otherwise.
-    pub fn verify_decrypted_signature_internal(
+    pub fn verify_decrypted_signature_wrapper(
         nonce_x_coordinate: GroupElement::Scalar,
         signature_s: GroupElement::Scalar,
         message: GroupElement::Scalar,

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -1,4 +1,4 @@
-// Author: dWallet Labs, Ltd.
+ // Author: dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use std::{
@@ -156,13 +156,13 @@ where
         Ok((self.nonce_x_coordinate, signature_s))
     }
 
-    /// A wrapper function for [`Self::verify_decrypted_signature_wrapper`] that uses self's
+    /// A wrapper function for [`Self::verify_decrypted_signature`] that uses self's
     /// attributes to verify the decrypted signature.
-    pub fn verify_decrypted_signature(
+    pub fn verify_decrypted_signature_wrapper(
         self,
         signature_s: GroupElement::Scalar,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
-        Self::verify_decrypted_signature_wrapper(
+        Self::verify_decrypted_signature(
             self.nonce_x_coordinate,
             signature_s,
             self.message,
@@ -174,7 +174,7 @@ where
     /// the decryption sent by the designated decrypting party.
     /// Returns a [`Error::MaliciousDesignatedDecryptingParty`] for an invalid signature,
     /// and accepts otherwise.
-    pub fn verify_decrypted_signature_wrapper(
+    pub fn verify_decrypted_signature(
         nonce_x_coordinate: GroupElement::Scalar,
         signature_s: GroupElement::Scalar,
         message: GroupElement::Scalar,

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -156,9 +156,8 @@ where
         Ok((self.nonce_x_coordinate, signature_s))
     }
 
-    /// The lightweight $$ O(1) $$ threshold decryption logic, which simply verifies the output of
-    /// the decryption sent by the designated decrypting party. Blames it in case of an invalid
-    /// signature, and accepts otherwise.
+    /// A wrapper function for [`Self::verify_decrypted_signature_static`] that uses self's
+    /// attributes to verify the decrypted signature.
     pub fn verify_decrypted_signature(
         self,
         signature_s: GroupElement::Scalar,

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -164,14 +164,34 @@ where
         signature_s: GroupElement::Scalar,
         designated_decrypting_party_id: PartyID,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
-        verify_signature(
-            self.nonce_x_coordinate,
+        Self::verify_decrypted_signature_static(
             signature_s,
+            designated_decrypting_party_id,
+            self.nonce_x_coordinate,
             self.message,
             self.public_key,
         )
+    }
+    /// The lightweight $$ O(1) $$ threshold decryption logic, which simply verifies the output of
+    /// the decryption sent by the designated decrypting party. Blames it in case of an invalid
+    /// signature, and accepts otherwise.
+    pub fn verify_decrypted_signature_static(
+        signature_s: GroupElement::Scalar,
+        designated_decrypting_party_id: PartyID,
+        nonce_x_coordinate: GroupElement::Scalar,
+        message: GroupElement::Scalar,
+        public_key: GroupElement,
+    ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
+        verify_signature(
+            nonce_x_coordinate,
+            signature_s,
+            message,
+            public_key,
+        )
         .map_err(|_| Error::MaliciousDesignatedDecryptingParty(designated_decrypting_party_id))?;
 
-        Ok((self.nonce_x_coordinate, signature_s))
+        Ok((nonce_x_coordinate, signature_s))
     }
+
+    //
 }

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -175,7 +175,6 @@ where
     /// Returns a [`Error::MaliciousDesignatedDecryptingParty`] for an invalid signature,
     /// and accepts otherwise.
     pub fn verify_decrypted_signature_wrapper(
-
         nonce_x_coordinate: GroupElement::Scalar,
         signature_s: GroupElement::Scalar,
         message: GroupElement::Scalar,

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -180,7 +180,7 @@ where
         public_key: GroupElement,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
         verify_signature(nonce_x_coordinate, signature_s, message, public_key)
-            .map_err(|_| Error::SignatureVerification)?;
+            .map_err(|_| Error::MaliciousDesignatedDecryptingParty)?;
 
         Ok((nonce_x_coordinate, signature_s))
     }

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -1,4 +1,4 @@
- // Author: dWallet Labs, Ltd.
+// Author: dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use std::{

--- a/src/sign/decentralized_party/signature_threshold_decryption_round.rs
+++ b/src/sign/decentralized_party/signature_threshold_decryption_round.rs
@@ -156,15 +156,15 @@ where
         Ok((self.nonce_x_coordinate, signature_s))
     }
 
-    /// A wrapper function for [`Self::verify_decrypted_signature_static`] that uses self's
+    /// A wrapper function for [`Self::verify_decrypted_signature_internal`] that uses self's
     /// attributes to verify the decrypted signature.
     pub fn verify_decrypted_signature(
         self,
         signature_s: GroupElement::Scalar,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {
-        Self::verify_decrypted_signature_static(
-            signature_s,
+        Self::verify_decrypted_signature_internal(
             self.nonce_x_coordinate,
+            signature_s,
             self.message,
             self.public_key,
         )
@@ -173,9 +173,9 @@ where
     /// The lightweight $$ O(1) $$ threshold decryption logic, which simply verifies the output of
     /// the decryption sent by the designated decrypting party. Returns a [`Error::SignatureVerification`]
     /// in case of an invalid signature, and accepts otherwise.
-    pub fn verify_decrypted_signature_static(
-        signature_s: GroupElement::Scalar,
+    pub fn verify_decrypted_signature_internal(
         nonce_x_coordinate: GroupElement::Scalar,
+        signature_s: GroupElement::Scalar,
         message: GroupElement::Scalar,
         public_key: GroupElement,
     ) -> crate::Result<(GroupElement::Scalar, GroupElement::Scalar)> {


### PR DESCRIPTION
This PR is being marked with a '!' because it changes the API of `SignaturePartialDecryptionProofParty::new`. https://github.com/dwallet-labs/dwallet-network/pull/122 will need to be merged when this pr is being merged.