### PR TITLE
chore: Make the `Output` `secret_key_share` field public

### DIFF
--- a/src/dkg/centralized_party/decommitment_round.rs
+++ b/src/dkg/centralized_party/decommitment_round.rs
@@ -16,7 +16,7 @@ use crate::{dkg::decentralized_party, ProtocolPublicParameters};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Output<GroupElementValue, ScalarValue, CiphertextSpaceValue> {
-    pub(crate) secret_key_share: ScalarValue,
+    pub secret_key_share: ScalarValue,
     pub(crate) public_key_share: GroupElementValue,
     pub public_key: GroupElementValue,
     pub encrypted_decentralized_party_secret_key_share: CiphertextSpaceValue,


### PR DESCRIPTION
I need it so I will be able to return the dwallet secret from the wasm & use it in my test.